### PR TITLE
Adding Procfile and buildpack-run.sh

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,0 +1,5 @@
+# This is buildpack-run.sh
+git clone https://github.com/Macley-Kun/avaire.git
+cp -r avaire/.git .
+cp src/main/resources/config.yml .
+rm -rf avaire/


### PR DESCRIPTION
This pull request adds the following:
Procfile: essential to tell the dyno (this is what runs the application) how to exactly start/run the application.
buildpack-run.sh: used in this buildpack: https://github.com/weibeld/heroku-buildpack-run what enables the user to define some commands before the next buildpack. For this build i used this to:
Clone the repository avaire.
Copy the .git folder one level up.
Copy the config.yml to the avaire.jar file. So it can be read.
Delete the avaire/ folder. As this cloned one is no longer needed.

What will it do?
As of now, users can now fork avaire's repo. And edit the config.yml to their liking. When they add the correct buildpacks their build succeeds and will be running.
What it won't do?
It won't have any effect to how avaire is running now. The files are only used if you prefer hosting in Heroku.
The files don't contain any template (app.json), and therefore the user has to add the following themselfs in their heroku app:
Buildpacks: (The order matters!)
https://github.com/weibeld/heroku-buildpack-run
heroku/gradle
Enviroment variables:
GRADLE_TASK build

What is left to do?
Avaire could/should use enviroment variables too instead of using the config.yml. This way, users don't expose their bot token/clientid/etc to the public. This way also enables users to quicker change these keys too. And finnaly, some configurations are automatically done for the user. Like the JAWSDB_URL enviroment variable, that is automatically set, when the mysql add-on is added.

If you have any question regrading the pull, please feel free to ask :-)

Refs:
https://devcenter.heroku.com/articles/procfile
https://github.com/weibeld/heroku-buildpack-run