### PR TITLE
Fix spelling mistake in the middleware

### DIFF
--- a/src/main/java/com/avairebot/middleware/global/IsCategoryEnabled.java
+++ b/src/main/java/com/avairebot/middleware/global/IsCategoryEnabled.java
@@ -64,7 +64,7 @@ public class IsCategoryEnabled extends Middleware {
 
         if (!channel.isCategoryEnabled(stack.getCommandContainer().getCategory())) {
             if (isHelpCommand(stack) && stack.isMentionableCommand()) {
-                MessageFactory.makeError(message, "The help command is disable in this channel, you can enable it by using the `:category` command.")
+                MessageFactory.makeError(message, "The help command is disabled in this channel, you can enable it by using the `:category` command.")
                     .set("category", CommandHandler.getCommand(ToggleCategoryCommand.class).getCommand().generateCommandTrigger(message))
                     .queue(success -> success.delete().queueAfter(15, TimeUnit.SECONDS, null, RestActionUtil.ignore));
             }


### PR DESCRIPTION
:+1: 