### PR TITLE
Fixes Heroku issue 2

### DIFF
--- a/app.json
+++ b/app.json
@@ -188,6 +188,9 @@
     },
     {
 		"url": "heroku/gradle"
-	}
+	},
+    {
+        "url": "https://github.com/650health/heroku-buildpack-run"
+    }
   ]
 }

--- a/app.json
+++ b/app.json
@@ -188,9 +188,9 @@
     },
     {
 		"url": "heroku/gradle"
-	 },
-    {
+	},
+	{
         "url": "https://github.com/650health/heroku-buildpack-run"
-    }
+	}
   ]
 }

--- a/app.json
+++ b/app.json
@@ -188,7 +188,7 @@
     },
     {
 		"url": "heroku/gradle"
-	},
+	 },
     {
         "url": "https://github.com/650health/heroku-buildpack-run"
     }

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,2 +1,5 @@
 # This is buildpack-run.sh
-rm -rf .git && rm -rf build/ && git clone https://github.com/avaire/avaire.git && cp -r avaire/.git . && cp src/main/resources/config.yml . && rm -rf avaire/ && echo script worked.
+# Trick to clone AvaIre's git into a seperate folder, copying .git to the top directory. Followed by putting the config.yml on the right place.
+rm -rf .git && git clone https://github.com/avaire/avaire.git && cp -r avaire/.git . && cp src/main/resources/config.yml . && rm -rf avaire/ && echo script worked.
+# Cleaning any build artifacts, done before and after the gradle proces.
+rm -rf build/ && echo cleaned out build artifacts.


### PR DESCRIPTION
Cleaning the build files that Gradle creates after compiling on Heroku.
Tested this, now the slug size is decreased from 307mb, to around 100mb.