### PR TITLE
Web heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: java -jar AvaIre.jar --no-colors -env
+worker: java -jar AvaIre.jar --no-colors -env

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: java -jar AvaIre.jar --no-colors -env --music
+web: java -jar AvaIre.jar --no-colors -env --music

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: java -jar AvaIre.jar --no-colors -env
+worker: java -jar AvaIre.jar --no-colors -env --music

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -jar AvaIre.jar --no-colors -env --music
+web: java -jar AvaIre.jar --no-colors -env

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -jar AvaIre.jar --no-colors -env --music
+worker: java -jar AvaIre.jar --no-colors -env --music

--- a/app.json
+++ b/app.json
@@ -170,7 +170,7 @@
     }
   },
   "formation": {
-    "web": {
+    "worker": {
       "quantity": 1,
       "size": "free"
     }

--- a/app.json
+++ b/app.json
@@ -11,7 +11,9 @@
     "Moderation",
     "Senither",
     "Java",
-    "Selfhosting"
+    "Selfhosting",
+    "Music Bot",
+    "Discord Music Bot"
   ],
   "website": "https://avairebot.com/",
   "repository": "https://github.com/avaire/avaire",
@@ -126,17 +128,12 @@
 	  "value": ""
     },
     "AVA_METRICS_ENABLED": {
-      "description": "This option determines if the web API should be enabled at all. As of now, this won't work on Heroku sadly.",
+      "description": "This option determines if the web API should be enabled at all. If you want to turn this off, you also need to change the Procfile from web to worker. Otherwise AvaIre won't stay up.",
 	  "required": true,
-	  "value": "false"
-    },
-    "AVA_METRICS_PORT": {
-      "description": "The port the API and metrics should be exposed to, the port must not be used by another application on the system. As of now, this won't work on Heroku sadly.",
-	  "required": true,
-	  "value": "1256"
+	  "value": "true"
     },
     "AVA_METRICS_AUTHTOKEN": {
-      "description": "This is the auth token that should be given to validate incoming vote requests. All requests withoud the auth header will be ignored. As of now, this won't work on Heroku sadly.",
+      "description": "This is the auth token that should be given to validate incoming vote requests. All requests withoud the auth header will be ignored.",
 	  "required": true,
 	  "value": "avaire-auth-token"
     },

--- a/app.json
+++ b/app.json
@@ -129,7 +129,7 @@
 	  "value": ""
     },
     "AVA_METRICS_ENABLED": {
-      "description": "This option determines if the web API should be enabled at all. If you want to turn this off, you also need to change the Procfile from web to worker. Otherwise AvaIre won't stay up.",
+      "description": "This option determines if the web API should be enabled at all. If you want to turn this off, instead enable the worker dyno, instead of web dyno in the resources tab. Otherwise AvaIre won't stay up.",
 	  "required": true,
 	  "value": "true"
     },

--- a/app.json
+++ b/app.json
@@ -18,6 +18,7 @@
   "website": "https://avairebot.com/",
   "repository": "https://github.com/avaire/avaire",
   "logo": "https://imgur.com/H8RCD5F.png",
+  "success_url": "/stats",
   "addons": [
 	{
 		"plan": "jawsdb:kitefin"

--- a/app.json
+++ b/app.json
@@ -169,7 +169,7 @@
     }
   },
   "formation": {
-    "worker": {
+    "web": {
       "quantity": 1,
       "size": "free"
     }

--- a/app.json
+++ b/app.json
@@ -203,7 +203,7 @@
     },
     {
 		"url": "heroku/gradle"
-	}
+	},
     {
 		"url": "https://github.com/650health/heroku-buildpack-run"
     }

--- a/src/main/java/com/avairebot/config/EnvironmentMacros.java
+++ b/src/main/java/com/avairebot/config/EnvironmentMacros.java
@@ -39,6 +39,11 @@ public class EnvironmentMacros {
     /**
      * Registers the default environment override macros.
      */
+    private static boolean registerHerokuMetricsPort() {
+    return EnvironmentOverride.registerMacro("port", ((environmentValue, configuration) -> {
+        configuration.set("metrics.port", environmentValue);
+        }));
+    }
     public static void registerDefaults() {
         if (!registerJAWSDB_URL()) {
             log.warn("Failed to register the JAWSDB_URL environment variable macro, a macro with that name is already registered.");

--- a/src/main/java/com/avairebot/config/EnvironmentMacros.java
+++ b/src/main/java/com/avairebot/config/EnvironmentMacros.java
@@ -43,9 +43,7 @@ public class EnvironmentMacros {
         if (!registerJAWSDB_URL()) {
             log.warn("Failed to register the JAWSDB_URL environment variable macro, a macro with that name is already registered.");
         }
-    }
 
-    public static void registerDefaults() {
         if (!registerPORT()) {
             log.warn("Failed to register the PORT environment variable macro, a macro with that name is already registered.");
         }
@@ -77,7 +75,7 @@ public class EnvironmentMacros {
         });
     }
     
-    private static boolean registerHerokuMetricsPort() {
+    private static boolean registerPORT() {
         return EnvironmentOverride.registerMacro("PORT", ((environmentValue, configuration) -> {
             configuration.set("metrics.port", environmentValue);
         }));

--- a/src/main/java/com/avairebot/config/EnvironmentMacros.java
+++ b/src/main/java/com/avairebot/config/EnvironmentMacros.java
@@ -39,15 +39,15 @@ public class EnvironmentMacros {
     /**
      * Registers the default environment override macros.
      */
-public static void registerDefaults() {
-    if (!registerJAWSDB_URL()) {
-        log.warn("Failed to register the JAWSDB_URL environment variable macro, a macro with that name is already registered.");
-    }
+    public static void registerDefaults() {
+        if (!registerJAWSDB_URL()) {
+            log.warn("Failed to register the JAWSDB_URL environment variable macro, a macro with that name is already registered.");
+        }
 
-    if (!registerMetricsPort()) {
-        log.warn("Failed to register the PORT environment variable macro, a macro with that name is already registered.");
+        if (!registerMetricsPort()) {
+            log.warn("Failed to register the PORT environment variable macro, a macro with that name is already registered.");
+        }
     }
-}
 
     private static boolean registerMetricsPort() {
         return EnvironmentOverride.registerMacro("PORT", (environmentValue, configuration) -> {

--- a/src/main/java/com/avairebot/config/EnvironmentMacros.java
+++ b/src/main/java/com/avairebot/config/EnvironmentMacros.java
@@ -40,7 +40,7 @@ public class EnvironmentMacros {
      * Registers the default environment override macros.
      */
     private static boolean registerHerokuMetricsPort() {
-    return EnvironmentOverride.registerMacro("port", ((environmentValue, configuration) -> {
+    return EnvironmentOverride.registerMacro("PORT", ((environmentValue, configuration) -> {
         configuration.set("metrics.port", environmentValue);
         }));
     }

--- a/src/main/java/com/avairebot/config/EnvironmentMacros.java
+++ b/src/main/java/com/avairebot/config/EnvironmentMacros.java
@@ -39,14 +39,15 @@ public class EnvironmentMacros {
     /**
      * Registers the default environment override macros.
      */
-    private static boolean registerHerokuMetricsPort() {
-    return EnvironmentOverride.registerMacro("PORT", ((environmentValue, configuration) -> {
-        configuration.set("metrics.port", environmentValue);
-        }));
-    }
     public static void registerDefaults() {
         if (!registerJAWSDB_URL()) {
             log.warn("Failed to register the JAWSDB_URL environment variable macro, a macro with that name is already registered.");
+        }
+    }
+
+    public static void registerDefaults() {
+        if (!registerPORT()) {
+            log.warn("Failed to register the PORT environment variable macro, a macro with that name is already registered.");
         }
     }
 
@@ -74,5 +75,11 @@ public class EnvironmentMacros {
             configuration.set("database.hostname", result.group(4));
             configuration.set("database.database", result.group(5));
         });
+    }
+    
+    private static boolean registerHerokuMetricsPort() {
+        return EnvironmentOverride.registerMacro("PORT", ((environmentValue, configuration) -> {
+            configuration.set("metrics.port", environmentValue);
+        }));
     }
 }

--- a/src/main/java/com/avairebot/config/EnvironmentMacros.java
+++ b/src/main/java/com/avairebot/config/EnvironmentMacros.java
@@ -44,7 +44,7 @@ public class EnvironmentMacros {
             log.warn("Failed to register the JAWSDB_URL environment variable macro, a macro with that name is already registered.");
         }
 
-        if (!registerPORT()) {
+        if (!register$PORT()) {
             log.warn("Failed to register the PORT environment variable macro, a macro with that name is already registered.");
         }
     }
@@ -75,8 +75,8 @@ public class EnvironmentMacros {
         });
     }
     
-    private static boolean registerPORT() {
-        return EnvironmentOverride.registerMacro("PORT", ((environmentValue, configuration) -> {
+    private static boolean register$PORT() {
+        return EnvironmentOverride.registerMacro("$PORT", ((environmentValue, configuration) -> {
             configuration.set("metrics.port", environmentValue);
         }));
     }

--- a/src/main/java/com/avairebot/config/EnvironmentMacros.java
+++ b/src/main/java/com/avairebot/config/EnvironmentMacros.java
@@ -39,15 +39,21 @@ public class EnvironmentMacros {
     /**
      * Registers the default environment override macros.
      */
-    public static void registerDefaults() {
-        if (!registerJAWSDB_URL()) {
-            log.warn("Failed to register the JAWSDB_URL environment variable macro, a macro with that name is already registered.");
-        }
-
-        if (!registerPORT()) {
-            log.warn("Failed to register the PORT environment variable macro, a macro with that name is already registered.");
-        }
+public static void registerDefaults() {
+    if (!registerJAWSDB_URL()) {
+        log.warn("Failed to register the JAWSDB_URL environment variable macro, a macro with that name is already registered.");
     }
+
+    if (!registerMetricsPort()) {
+        log.warn("Failed to register the PORT environment variable macro, a macro with that name is already registered.");
+    }
+}
+
+private static boolean registerMetricsPort() {
+    return EnvironmentOverride.registerMacro("PORT", (environmentValue, configuration) -> {
+        configuration.set("metrics.port", Integer.valueOf(environmentValue));
+    });
+}
 
     private static boolean registerJAWSDB_URL() {
         return EnvironmentOverride.registerMacro("JAWSDB_URL", (environmentValue, configuration) -> {
@@ -73,11 +79,5 @@ public class EnvironmentMacros {
             configuration.set("database.hostname", result.group(4));
             configuration.set("database.database", result.group(5));
         });
-    }
-    
-    private static boolean registerPORT() {
-        return EnvironmentOverride.registerMacro("PORT", ((environmentValue, configuration) -> {
-            configuration.set("metrics.port", environmentValue);
-        }));
     }
 }

--- a/src/main/java/com/avairebot/config/EnvironmentMacros.java
+++ b/src/main/java/com/avairebot/config/EnvironmentMacros.java
@@ -49,11 +49,11 @@ public static void registerDefaults() {
     }
 }
 
-private static boolean registerMetricsPort() {
-    return EnvironmentOverride.registerMacro("PORT", (environmentValue, configuration) -> {
-        configuration.set("metrics.port", Integer.valueOf(environmentValue));
-    });
-}
+    private static boolean registerMetricsPort() {
+        return EnvironmentOverride.registerMacro("PORT", (environmentValue, configuration) -> {
+            configuration.set("metrics.port", Integer.valueOf(environmentValue));
+        });
+    }
 
     private static boolean registerJAWSDB_URL() {
         return EnvironmentOverride.registerMacro("JAWSDB_URL", (environmentValue, configuration) -> {

--- a/src/main/java/com/avairebot/config/EnvironmentMacros.java
+++ b/src/main/java/com/avairebot/config/EnvironmentMacros.java
@@ -44,7 +44,7 @@ public class EnvironmentMacros {
             log.warn("Failed to register the JAWSDB_URL environment variable macro, a macro with that name is already registered.");
         }
 
-        if (!register$PORT()) {
+        if (!registerPORT()) {
             log.warn("Failed to register the PORT environment variable macro, a macro with that name is already registered.");
         }
     }
@@ -75,8 +75,8 @@ public class EnvironmentMacros {
         });
     }
     
-    private static boolean register$PORT() {
-        return EnvironmentOverride.registerMacro("$PORT", ((environmentValue, configuration) -> {
+    private static boolean registerPORT() {
+        return EnvironmentOverride.registerMacro("PORT", ((environmentValue, configuration) -> {
             configuration.set("metrics.port", environmentValue);
         }));
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -204,16 +204,16 @@ system-prefix: ';'
 playing:
   - 'watching:deltabot.me'
   - 'streaming:my bits & bites 🎥🥵'
-  - 'playing:with my myself- ✯`
+  - 'playing:with my myself- ✯'
   - 'watching:over %users% users'
   - 'watching:in %guilds% servers'
   - 'listening:to some music 🎶'
   - 'streaming: Lofi Hiphop 🎧'
   - 'watching:the news 📰'
   - 'playing:on the 💻'
-  - `streaming: Pixels @ deltabot.me/dzone`
-  - `watching:the sunset 🌇`
-  - `playing: with 👻👻👻😨`
+  - 'streaming: Pixels @ deltabot.me/dzone'
+  - 'watching:the sunset 🌇'
+  - 'playing: with 👻👻👻😨'
 
 #--------------------------------------------------------------------------
 # Music Lavalink Nodes (Advanced Music Settings)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -207,13 +207,13 @@ playing:
   - 'playing:with my myself- ✯'
   - 'watching:over %users% users'
   - 'watching:in %guilds% servers'
-  - 'listening:to some music 🎶'
-  - 'streaming: Lofi Hiphop 🎧'
+  - 'listening:some music 🎶'
+  - 'streaming:Lofi Hiphop 🎧'
   - 'watching:the news 📰'
   - 'playing:on the 💻'
-  - 'streaming: Pixels @ deltabot.me/dzone'
+  - 'streaming:Pixels @ deltabot.me/dzone'
   - 'watching:the sunset 🌇'
-  - 'playing: with 👻👻👻😨'
+  - 'playing:with 👻👻👻😨'
 
 #--------------------------------------------------------------------------
 # Music Lavalink Nodes (Advanced Music Settings)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -211,7 +211,7 @@ playing:
   - 'streaming:Lofi Hiphop 🎧'
   - 'watching:the news 📰'
   - 'playing:on the 💻'
-  - 'streaming:Pixels @ deltabot.me/dzone'
+  - 'streaming: @ deltabot.me/dzone'
   - 'watching:the sunset 🌇'
   - 'playing:with 👻👻👻😨'
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -202,7 +202,18 @@ system-prefix: ';'
 #
 
 playing:
-  - ''
+  - 'watching:deltabot.me'
+  - 'streaming:my bits & bites 🎥🥵'
+  - 'playing:with my myself- ✯`
+  - 'watching:over %users% users'
+  - 'watching:in %guilds% servers'
+  - 'listening:to some music 🎶'
+  - 'streaming: Lofi Hiphop 🎧'
+  - 'watching:the news 📰'
+  - 'playing:on the 💻'
+  - `streaming: Pixels @ deltabot.me/dzone`
+  - `watching:the sunset 🌇`
+  - `playing: with 👻👻👻😨`
 
 #--------------------------------------------------------------------------
 # Music Lavalink Nodes (Advanced Music Settings)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -202,7 +202,7 @@ system-prefix: ';'
 #
 
 playing:
-  - ' '
+  - ''
 
 #--------------------------------------------------------------------------
 # Music Lavalink Nodes (Advanced Music Settings)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -202,18 +202,10 @@ system-prefix: ';'
 #
 
 playing:
-  - 'watching:deltabot.me'
-  - 'streaming:my bits & bites 🎥🥵'
-  - 'playing:with my myself- ✯'
-  - 'watching:over %users% users'
-  - 'watching:in %guilds% servers'
-  - 'listening:some music 🎶'
-  - 'streaming:Lofi Hiphop 🎧'
-  - 'watching:the news 📰'
-  - 'playing:on the 💻'
-  - 'streaming: @ deltabot.me/dzone'
-  - 'watching:the sunset 🌇'
-  - 'playing:with 👻👻👻😨'
+  - '!help'
+  - 'watching:avairebot.com'
+  - 'listening:%users% users'
+  - 'playing:in %guilds% servers'
 
 #--------------------------------------------------------------------------
 # Music Lavalink Nodes (Advanced Music Settings)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -202,10 +202,7 @@ system-prefix: ';'
 #
 
 playing:
-  - '!help'
-  - 'watching:avairebot.com'
-  - 'listening:%users% users'
-  - 'playing:in %guilds% servers'
+  - ' '
 
 #--------------------------------------------------------------------------
 # Music Lavalink Nodes (Advanced Music Settings)

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=9
+java.runtime.version=11

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=11
+java.runtime.version=10

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=10
+java.runtime.version=9


### PR DESCRIPTION
https://github.com/avaire/avaire/issues/56
Solves the first and "biggest" issue of them all.

Thanks for the help again Senither :P 

This pull will do the following:

- Add a second option to start the bot, using the web worker now will enable the API of AvaIre.
- Added success_url to land after deploying on a "meaningfull" place, instead of a blank/error page. 
- Removed env variable for the port, as this isn't needed in Heroku, if used.
- Default dyno changed from worker to web. (Users now need to use something to keep AvaIre up, will doc this with solutions like Uptime Robot (and something what @chaNcharge as made in the past).
- Actully using the requested JDK as in the docs for selfhosting. What i clearly have read before doing all this.

Tested this couple of times, everything works as aspected.
