### PR TITLE
Add pull.yml since Backstroke has shut down

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,6 @@
+version: "1"
+rules:
+  - base: master
+    upstream: avaire:master
+    autoMerge: true
+    autoMergeHardReset: false


### PR DESCRIPTION
Backstroke has shut down, so I'm updating one of AvaIre's selfhosted update methods. There's a GitHub app called Pull that selfhosters can install on their own repos. I'll update the docs with the new instructions to set up. However, I'm keeping my script around in case Pull shuts down in the future also. 