### PR TITLE
Resolve web & worker dyno both being on

### DIFF
--- a/app.json
+++ b/app.json
@@ -201,7 +201,11 @@
     "worker": {
       "quantity": 1,
       "size": "free"
-    }
+	},
+      "web": {
+      "quantity": 0,
+      "size": "free"
+	}
   },
   "buildpacks": [
 	{


### PR DESCRIPTION
This commit/pull will fix an overlooked issue where if the user would deploy with the template, both web and worker dyno's would be running. Therefore the bot is being runned twice.

By defining the web worker, but setting it's quantity to 0, it will not be toggelt on by default.
Will do a pull (same exact wording) on Watchdog.