### PR TITLE
Fix duplicate issue creation in update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -16,8 +16,8 @@ CONFLICTS=$(git ls-files -u | wc -l)
 if [ "$CONFLICTS" -gt 0 ] ; then
     echo "There is a merge conflict. Aborting"
     git merge --abort
-    conflicts=$(curl https://api.github.com/search/issues?q=is:issue+is:open+repo:$GITHUB_REPO+author:$GITHUB_USER+label:merge-conflict | grep "url") # I would use jq, but for simple heroku purposes, I'll use a dirty way
-    if [ -n "$var" ] ; then
+    conflictcheck=$(curl https://api.github.com/search/issues\?q\=is:issue+is:open+repo:$GITHUB_REPO+author:$GITHUB_USER+label:merge-conflict | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["total_count"]') # I would use jq, but to minimize deps, I'll use a dirty way
+    if [ $conflictcheck -eq 0 ] ; then
         curl -u $GITHUB_USER:$GITHUB_SECRET_TOKEN -H "Content-Type: application/json" -X POST -d '{"title": "Merge conflict detected", "body": "ForkUpdater could not update your repo. Please check for merge conflicts and update manually!","labels": ["merge-conflict"]}' https://api.github.com/repos/$GITHUB_REPO/issues
     fi
     exit 1
@@ -26,5 +26,5 @@ fi
 git checkout $GITHUB_REPO_BRANCH
 git merge --no-edit --no-ff upstream
 
-# Redirect to /dev/null to avoid secret leakage
+Redirect to /dev/null to avoid secret leakage
 git push "$push_uri" $GITHUB_REPO_BRANCH >/dev/null 2>&1

--- a/update.sh
+++ b/update.sh
@@ -4,7 +4,7 @@ GITHUB_USER=$(cut -d/ -f1 <<< "$GITHUB_REPO")
 repo_temp=$(mktemp -d)
 push_uri="https://$GITHUB_USER:$GITHUB_SECRET_TOKEN@github.com/$GITHUB_REPO"
 
-git config --global user.email "updater@updater" && git config --global user.name "AutoUpdater"
+git config --global user.email "updater@updater" && git config --global user.name "ForkUpdater"
 
 git clone "https://github.com/$GITHUB_REPO" "$repo_temp"
 cd "$repo_temp"
@@ -16,7 +16,10 @@ CONFLICTS=$(git ls-files -u | wc -l)
 if [ "$CONFLICTS" -gt 0 ] ; then
     echo "There is a merge conflict. Aborting"
     git merge --abort
-    curl -u $GITHUB_USER:$GITHUB_SECRET_TOKEN -H "Content-Type: application/json" -X POST -d '{"title": "Merge conflict detected", "body": "Heroku could not update your repo. Please check for merge conflicts and update manually!","labels": ["merge conflict"]}' https://api.github.com/repos/$GITHUB_REPO/issues
+    conflicts=$(curl https://api.github.com/search/issues?q=is:issue+is:open+repo:$GITHUB_REPO+author:$GITHUB_USER+label:merge-conflict | grep "url") # I would use jq, but for simple heroku purposes, I'll use a dirty way
+    if [ -n "$var" ] ; then
+        curl -u $GITHUB_USER:$GITHUB_SECRET_TOKEN -H "Content-Type: application/json" -X POST -d '{"title": "Merge conflict detected", "body": "ForkUpdater could not update your repo. Please check for merge conflicts and update manually!","labels": ["merge-conflict"]}' https://api.github.com/repos/$GITHUB_REPO/issues
+    fi
     exit 1
 fi
 

--- a/update.sh
+++ b/update.sh
@@ -26,5 +26,5 @@ fi
 git checkout $GITHUB_REPO_BRANCH
 git merge --no-edit --no-ff upstream
 
-Redirect to /dev/null to avoid secret leakage
+# Redirect to /dev/null to avoid secret leakage
 git push "$push_uri" $GITHUB_REPO_BRANCH >/dev/null 2>&1


### PR DESCRIPTION
This update to the update script checks for any issue with the `merge-conflict` tag and if one already exists, it will no longer create duplicate issues and spam your issues page.

Thanks to @Macley-Kun for finding this issue!