### PR TITLE
Create image rank backgrounds feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'idea'
 
-version = '0.9.9'
+version = '0.9.10'
 group = 'com.avairebot'
 description = 'AvaIre Discord Bot'
 mainClassName = 'com.avairebot.Main'

--- a/src/main/java/com/avairebot/Constants.java
+++ b/src/main/java/com/avairebot/Constants.java
@@ -41,6 +41,7 @@ public class Constants {
     public static final String LOG_TABLE_NAME = "logs";
     public static final String LOG_TYPES_TABLE_NAME = "log_types";
     public static final String REACTION_ROLES_TABLE_NAME = "reaction_roles";
+    public static final String PURCHASES_TABLE_NAME = "purchases";
 
     // Package Specific Information
     public static final String PACKAGE_MIGRATION_PATH = "com.avairebot.database.migrate";

--- a/src/main/java/com/avairebot/Constants.java
+++ b/src/main/java/com/avairebot/Constants.java
@@ -54,6 +54,9 @@ public class Constants {
     public static final String EMOTE_AWAY = "<:away:324986135346675712>";
     public static final String EMOTE_DND = "<:dnd:324986174806425610>";
 
+    // Purchase Types
+    public static final String RANK_BACKGROUND_PURCHASE_TYPE = "rank-background";
+
     // Command source link
     public static final String SOURCE_URI = "https://github.com/avaire/avaire/tree/master/src/main/java/com/avairebot/commands/%s/%s.java";
 }

--- a/src/main/java/com/avairebot/commands/utility/RankBackgroundCommand.java
+++ b/src/main/java/com/avairebot/commands/utility/RankBackgroundCommand.java
@@ -163,7 +163,7 @@ public class RankBackgroundCommand extends Command {
         String purchaseType = RankBackgrounds.getDefaultBackground().getPurchaseType();
         paginator.forEach((index, name, cost) -> {
             //noinspection ConstantConditions
-            boolean alreadyOwns = player.hasPurchases() && player.getPurchases().hasPuraches(
+            boolean alreadyOwns = player.hasPurchases() && player.getPurchases().hasPurchase(
                 purchaseType, RankBackgrounds.fromName((String) name).getId()
             );
 
@@ -243,7 +243,7 @@ public class RankBackgroundCommand extends Command {
             return sendErrorMessage(context, "errors.errorOccurredWhileLoading", "player transformer");
         }
 
-        if (player.getPurchases().hasPuraches(background.getPurchaseType(), background.getId())) {
+        if (player.getPurchases().hasPurchase(background.getPurchaseType(), background.getId())) {
             context.makeWarning("You already own the **:name** background!")
                 .set("name", background.getName())
                 .queue();

--- a/src/main/java/com/avairebot/commands/utility/RankBackgroundCommand.java
+++ b/src/main/java/com/avairebot/commands/utility/RankBackgroundCommand.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.commands.utility;
+
+import com.avairebot.AvaIre;
+import com.avairebot.commands.CommandMessage;
+import com.avairebot.contracts.commands.Command;
+import com.avairebot.contracts.commands.CommandGroup;
+import com.avairebot.contracts.commands.CommandGroups;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class RankBackgroundCommand extends Command {
+
+    public RankBackgroundCommand(AvaIre avaire) {
+        super(avaire, false);
+    }
+
+    @Override
+    public String getName() {
+        return "Rank Background Command";
+    }
+
+    @Override
+    public String getDescription() {
+        return "TODO";
+    }
+
+    @Override
+    public List<String> getUsageInstructions() {
+        return Arrays.asList(
+            "TODO"
+        );
+    }
+
+    @Override
+    public List<String> getExampleUsage() {
+        return Collections.singletonList(":command");
+    }
+
+    @Override
+    public List<Class<? extends Command>> getRelations() {
+        return Collections.singletonList(
+            RankCommand.class
+        );
+    }
+
+    @Override
+    public List<String> getTriggers() {
+        return Arrays.asList("backgrounds", "rankbg", "levelbg");
+    }
+
+    @Override
+    public List<String> getMiddleware() {
+        return Collections.singletonList("throttle:user,1,5");
+    }
+
+    @Nonnull
+    @Override
+    public List<CommandGroup> getGroups() {
+        return Collections.singletonList(CommandGroups.LEVEL_AND_EXPERIENCE);
+    }
+
+    @Override
+    public boolean onCommand(CommandMessage context, String[] args) {
+        if (args.length == 0) {
+            return sendErrorMessage(context, "errors.missingArgument", "option");
+        }
+
+        switch (args[0].toLowerCase().trim()) {
+            case "list":
+                return handleList(context, prepareArguments(args));
+
+            case "show":
+            case "test":
+                return handleShow(context, prepareArguments(args));
+
+            case "buy":
+            case "purchases":
+                return handlePurchases(context, prepareArguments(args));
+
+            default:
+                return sendErrorMessage(context, "errors.invalidProperty", "option", "option");
+        }
+    }
+
+    private boolean handleList(CommandMessage context, String[] args) {
+        return false;
+    }
+
+    private boolean handleShow(CommandMessage context, String[] args) {
+        return false;
+    }
+
+    private boolean handlePurchases(CommandMessage context, String[] args) {
+        return false;
+    }
+
+    private String[] prepareArguments(String[] args) {
+        return Arrays.copyOfRange(args, 1, args.length);
+    }
+}

--- a/src/main/java/com/avairebot/commands/utility/RankBackgroundCommand.java
+++ b/src/main/java/com/avairebot/commands/utility/RankBackgroundCommand.java
@@ -26,6 +26,7 @@ import com.avairebot.Constants;
 import com.avairebot.chat.SimplePaginator;
 import com.avairebot.commands.CommandMessage;
 import com.avairebot.contracts.commands.Command;
+import com.avairebot.contracts.commands.CommandContext;
 import com.avairebot.contracts.commands.CommandGroup;
 import com.avairebot.contracts.commands.CommandGroups;
 import com.avairebot.database.controllers.PlayerController;
@@ -33,6 +34,7 @@ import com.avairebot.database.transformers.PlayerTransformer;
 import com.avairebot.imagegen.RankBackgrounds;
 import com.avairebot.imagegen.renders.RankBackgroundRender;
 import com.avairebot.language.I18n;
+import com.avairebot.shared.DiscordConstants;
 import com.avairebot.utilities.NumberUtil;
 import com.avairebot.utilities.RandomUtil;
 import com.avairebot.vote.VoteCacheEntity;
@@ -63,21 +65,37 @@ public class RankBackgroundCommand extends Command {
         return "Rank Background Command";
     }
 
+
     @Override
-    public String getDescription() {
-        return "TODO";
+    public String getDescription(CommandContext context) {
+        String prefix = context.isGuildMessage() ? generateCommandPrefix(context.getMessage()) : DiscordConstants.DEFAULT_COMMAND_PREFIX;
+
+        return String.format(String.join("\n",
+            "Rank backgrounds are used for the `%srank` command, when a user has a rank",
+            "background selected, their rank and experience will be displayed using a generated",
+            "image instead, the background image can be changed at any time.",
+            "You can buy backgrounds using [vote points](https://discordbots.org/bot/avaire), use `%svote` for more info."
+        ), prefix, prefix);
     }
 
     @Override
     public List<String> getUsageInstructions() {
         return Arrays.asList(
-            "TODO"
+            "`:command list` - Lists all the backgrounds available.",
+            "`:command test <name>` - Displays an example of how the background will look like if you buy it.",
+            "`:command buy <name>` - Buys the background with vote points.",
+            "`:command use <name>` - Selects the background so it is used in the future for rank commands."
         );
     }
 
     @Override
     public List<String> getExampleUsage() {
-        return Collections.singletonList(":command");
+        return Arrays.asList(
+            "`:command list`",
+            "`:command test discord dark theme`",
+            "`:command buy discord dark theme`",
+            "`:command use discord dark theme`"
+        );
     }
 
     @Override

--- a/src/main/java/com/avairebot/commands/utility/RankBackgroundCommand.java
+++ b/src/main/java/com/avairebot/commands/utility/RankBackgroundCommand.java
@@ -65,7 +65,6 @@ public class RankBackgroundCommand extends Command {
         return "Rank Background Command";
     }
 
-
     @Override
     public String getDescription(CommandContext context) {
         String prefix = context.isGuildMessage() ? generateCommandPrefix(context.getMessage()) : DiscordConstants.DEFAULT_COMMAND_PREFIX;

--- a/src/main/java/com/avairebot/commands/utility/RankCommand.java
+++ b/src/main/java/com/avairebot/commands/utility/RankCommand.java
@@ -36,16 +36,23 @@ import com.avairebot.database.controllers.PlayerController;
 import com.avairebot.database.transformers.GuildTransformer;
 import com.avairebot.database.transformers.PlayerTransformer;
 import com.avairebot.factories.MessageFactory;
+import com.avairebot.imagegen.RankBackgrounds;
+import com.avairebot.imagegen.renders.RankBackgroundRender;
+import com.avairebot.language.I18n;
 import com.avairebot.utilities.CacheUtil;
 import com.avairebot.utilities.MentionableUtil;
 import com.avairebot.utilities.NumberUtil;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import net.dv8tion.jda.core.EmbedBuilder;
+import net.dv8tion.jda.core.MessageBuilder;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.User;
 
 import javax.annotation.Nonnull;
 import java.awt.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -164,22 +171,128 @@ public class RankCommand extends Command {
                 levelBar += ((i * 2.5) < percentage) ? "\u2592" : "\u2591";
             }
 
-            MessageFactory.makeEmbeddedMessage(context.getChannel(), Color.decode("#E91E63"))
-                .setAuthor(author.getName(), "https://avairebot.com/leaderboard/" + context.getGuild().getId(), author.getEffectiveAvatarUrl())
-                .setFooter("https://avairebot.com/leaderboard/" + context.getGuild().getId())
-                .addField(context.i18n("fields.rank"), score, true)
-                .addField(context.i18n("fields.level"), NumberUtil.formatNicely(level), true)
-                .addField(context.i18n("fields.experience"), (experience - zeroExperience - 100 < 0 ? "0" : context.i18n("fields.total",
-                    NumberUtil.formatNicely(experience - zeroExperience - 100), NumberUtil.formatNicely(properties.getTotal())
-                )), true)
-                .addField(context.i18n("fields.experienceToNext"), context.i18n("fields.youNeedMoreXpToLevelUp",
-                    levelBar, NumberUtil.formatNicelyWithDecimals(percentage), '%', NumberUtil.formatNicely(nextLevelXp - experience)
-                ), false)
-                .requestedBy(context.getMember())
-                .queue();
+            PlayerTransformer playerTransformer = context.getPlayerTransformer();
+            if (playerTransformer != null) {
+                Integer selectedBackgroundId = playerTransformer.getPurchases()
+                    .getSelectedPurchasesForType(
+                        RankBackgrounds.getDefaultBackground().getPurchaseType()
+                    );
+
+                if (selectedBackgroundId != null) {
+                    sendBackgroundMessage(
+                        context, author,
+                        score, levelBar,
+                        level, nextLevelXp,
+                        experience, zeroExperience,
+                        percentage,
+                        properties,
+                        selectedBackgroundId
+                    );
+                    return;
+                }
+            }
+
+            sendEmbeddedMessage(
+                context, author,
+                score, levelBar,
+                level, nextLevelXp,
+                experience, zeroExperience,
+                percentage,
+                properties
+            );
         });
 
         return true;
+    }
+
+    private void sendEmbeddedMessage(
+        CommandMessage context,
+        User author,
+        String score,
+        String levelBar,
+        long level,
+        long nextLevelXp,
+        long experience,
+        long zeroExperience,
+        double percentage,
+        DatabaseProperties properties
+    ) {
+        MessageFactory.makeEmbeddedMessage(context.getChannel(), Color.decode("#E91E63"))
+            .setAuthor(author.getName(), "https://avairebot.com/leaderboard/" + context.getGuild().getId(), author.getEffectiveAvatarUrl())
+            .setFooter("https://avairebot.com/leaderboard/" + context.getGuild().getId())
+            .addField(context.i18n("fields.rank"), score, true)
+            .addField(context.i18n("fields.level"), NumberUtil.formatNicely(level), true)
+            .addField(context.i18n("fields.experience"), (experience - zeroExperience - 100 < 0 ? "0" : context.i18n("fields.total",
+                NumberUtil.formatNicely(experience - zeroExperience - 100), NumberUtil.formatNicely(properties.getTotal())
+            )), true)
+            .addField(context.i18n("fields.experienceToNext"), context.i18n("fields.youNeedMoreXpToLevelUp",
+                levelBar, NumberUtil.formatNicelyWithDecimals(percentage), '%', NumberUtil.formatNicely(nextLevelXp - experience)
+            ), false)
+            .requestedBy(context.getMember())
+            .queue();
+    }
+
+    private void sendBackgroundMessage(
+        CommandMessage context,
+        User author,
+        String score,
+        String levelBar,
+        long level,
+        long nextLevelXp,
+        long experience,
+        long zeroExperience,
+        double percentage,
+        DatabaseProperties properties,
+        int backgroundId
+    ) {
+        RankBackgrounds background = RankBackgrounds.fromId(backgroundId);
+        if (background == null) {
+            sendEmbeddedMessage(
+                context, author,
+                score, levelBar,
+                level, nextLevelXp,
+                experience, zeroExperience,
+                percentage,
+                properties
+            );
+            return;
+        }
+
+        long xpForCurrentLevel = avaire.getLevelManager().getExperienceFromLevel(
+            context.getGuildTransformer(), level
+        );
+
+        RankBackgroundRender render = new RankBackgroundRender(context.getAuthor())
+            .setBackground(background)
+            .setCurrentXpInLevel(NumberUtil.formatNicely(experience - xpForCurrentLevel))
+            .setTotalXpInLevel(NumberUtil.formatNicely(nextLevelXp - xpForCurrentLevel))
+            .setGlobalExperience(NumberUtil.formatNicely(properties.getTotal()))
+            .setServerExperience(NumberUtil.formatNicely(experience - zeroExperience - 100))
+            .setLevel(NumberUtil.formatNicely(level))
+            .setRank(properties.getScore())
+            .setPercentage(percentage);
+
+        String attachmentName = I18n.format(
+            "{0}-{1}-rank-bg.png",
+            context.getGuild().getIdLong(),
+            author.getId()
+        );
+
+        MessageBuilder message = new MessageBuilder();
+        EmbedBuilder embed = new EmbedBuilder()
+            .setImage("attachment://" + attachmentName)
+            .setColor(background.getBackgroundColors().getExperienceForegroundColor());
+        message.setEmbed(embed.build());
+
+        try {
+            //noinspection ConstantConditions
+            context.getMessageChannel().sendFile(
+                new ByteArrayInputStream(render.renderToBytes()),
+                attachmentName, message.build()
+            ).queue();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     private CompletableFuture<DatabaseProperties> loadProperties(CommandMessage context, User author) {

--- a/src/main/java/com/avairebot/commands/utility/RankCommand.java
+++ b/src/main/java/com/avairebot/commands/utility/RankCommand.java
@@ -92,7 +92,8 @@ public class RankCommand extends Command {
     public List<Class<? extends Command>> getRelations() {
         return Arrays.asList(
             LeaderboardCommand.class,
-            GlobalLeaderboardCommand.class
+            GlobalLeaderboardCommand.class,
+            RankBackgroundCommand.class
         );
     }
 

--- a/src/main/java/com/avairebot/contracts/chat/Paginator.java
+++ b/src/main/java/com/avairebot/contracts/chat/Paginator.java
@@ -24,8 +24,8 @@ package com.avairebot.contracts.chat;
 import com.avairebot.utilities.NumberUtil;
 
 import javax.annotation.Nonnull;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -35,7 +35,7 @@ public abstract class Paginator implements Cloneable {
     /**
      * The items that should be paginated.
      */
-    protected final Map<Object, Object> items;
+    protected final LinkedHashMap<Object, Object> items;
 
     /**
      * The amount of items to display per-page.
@@ -56,7 +56,7 @@ public abstract class Paginator implements Cloneable {
      * @param currentPage The current page that should be shown.
      */
     public Paginator(@Nonnull Map<?, ?> items, int perPage, int currentPage) {
-        this.items = new HashMap<>(items);
+        this.items = new LinkedHashMap<>(items);
         this.perPage = perPage;
 
         this.setCurrentPage(currentPage);
@@ -86,7 +86,7 @@ public abstract class Paginator implements Cloneable {
      * @param currentPage The current page that should be shown.
      */
     public Paginator(@Nonnull List<?> items, int perPage, int currentPage) {
-        Map<Object, Object> map = new HashMap<>();
+        LinkedHashMap<Object, Object> map = new LinkedHashMap<>();
         for (int i = 0; i < items.size(); i++) {
             map.put(i, items.get(i));
         }
@@ -124,7 +124,7 @@ public abstract class Paginator implements Cloneable {
      */
     public Paginator(@Nonnull Iterator<?> iterator, int perPage, int currentPage) {
         int index = 0;
-        Map<Object, Object> items = new HashMap<>();
+        LinkedHashMap<Object, Object> items = new LinkedHashMap<>();
         while (iterator.hasNext()) {
             items.put(index++, iterator.next());
         }

--- a/src/main/java/com/avairebot/contracts/database/transformers/Transformer.java
+++ b/src/main/java/com/avairebot/contracts/database/transformers/Transformer.java
@@ -42,6 +42,11 @@ public abstract class Transformer extends Evalable implements ConfigurationSeria
     protected boolean hasData;
 
     /**
+     * Determines if the transformer has been checked if it has any data or not.
+     */
+    private boolean hasBeenChecked;
+
+    /**
      * Creates a new transformer instance using
      * the given data row object.
      *
@@ -50,7 +55,7 @@ public abstract class Transformer extends Evalable implements ConfigurationSeria
      */
     public Transformer(DataRow data) {
         this.data = data;
-        hasData = (data != null);
+        this.hasBeenChecked = false;
     }
 
     /**
@@ -70,8 +75,21 @@ public abstract class Transformer extends Evalable implements ConfigurationSeria
      *
      * @return {@code True} if the transformer has data, {@code False} otherwise.
      */
-    public boolean hasData() {
+    public final boolean hasData() {
+        if (!hasBeenChecked) {
+            hasData = checkIfTransformerHasData();
+            hasBeenChecked = true;
+        }
         return hasData;
+    }
+
+    /**
+     * Checks if the transformer has any data.
+     *
+     * @return {@code True} if the transformer has data, {@code False} otherwise.
+     */
+    protected boolean checkIfTransformerHasData() {
+        return data != null;
     }
 
     @Override

--- a/src/main/java/com/avairebot/contracts/shop/PurchaseType.java
+++ b/src/main/java/com/avairebot/contracts/shop/PurchaseType.java
@@ -37,4 +37,12 @@ public interface PurchaseType extends Reflectional {
      */
     @Nonnull
     String getPurchaseType();
+
+    /**
+     * Returns the cost of the item, the cost will be used
+     * to determine if the user can buy the item.
+     *
+     * @return The cost of the item.
+     */
+    int getCost();
 }

--- a/src/main/java/com/avairebot/contracts/shop/PurchaseType.java
+++ b/src/main/java/com/avairebot/contracts/shop/PurchaseType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.contracts.shop;
+
+import com.avairebot.contracts.reflection.Reflectional;
+
+import javax.annotation.Nonnull;
+
+public interface PurchaseType extends Reflectional {
+
+    /**
+     * Returns the purchase type, the type is used in the purchases table for
+     * tracking what the user bought by type, allowing the user to buy two
+     * different things with the same ID, but belonging to different
+     * purchases types.
+     *
+     * @return The purchase type used to represent the object in the database.
+     */
+    @Nonnull
+    String getPurchaseType();
+}

--- a/src/main/java/com/avairebot/database/controllers/PlayerController.java
+++ b/src/main/java/com/avairebot/database/controllers/PlayerController.java
@@ -55,6 +55,10 @@ public class PlayerController {
         "`experiences`.`experience`", "count(`purchases`.`user_id`) as purchases"
     };
 
+    private static final String[] requiredPurchasesColumns = new String[]{
+        "`purchases`.`type`", "`purchases`.`type_id`", "`votes`.`selected_bg` as 'selected'"
+    };
+
     @CheckReturnValue
     public static PlayerTransformer fetchPlayer(AvaIre avaire, Message message) {
         return fetchPlayer(avaire, message, message.getAuthor());
@@ -105,8 +109,9 @@ public class PlayerController {
                 if (transformer.hasPurchases()) {
                     transformer.setPurchases(new PurchasesTransformer(
                         avaire.getDatabase().newQueryBuilder(Constants.PURCHASES_TABLE_NAME)
-                            .select("type", "type_id")
-                            .where("user_id", user.getIdLong())
+                            .selectRaw(String.join(", ", requiredPurchasesColumns))
+                            .leftJoin(Constants.VOTES_TABLE_NAME, "votes.selected_bg", "purchases.type_id")
+                            .where("purchases.user_id", user.getIdLong())
                             .get()
                     ));
                 }

--- a/src/main/java/com/avairebot/database/controllers/PlayerController.java
+++ b/src/main/java/com/avairebot/database/controllers/PlayerController.java
@@ -159,6 +159,19 @@ public class PlayerController {
         return guild.getId() + ":" + user.getId();
     }
 
+    public static void forgetCache(long userId) {
+        List<String> toRemove = new ArrayList<>();
+        for (String key : cache.asMap().keySet()) {
+            if (key.endsWith(":" + userId)) {
+                toRemove.add(key);
+            }
+        }
+
+        if (!toRemove.isEmpty()) {
+            cache.invalidateAll(toRemove);
+        }
+    }
+
     public static class PlayerUpdateReference {
 
         private final String username;

--- a/src/main/java/com/avairebot/database/migrate/migrations/AddSelectedBackgroundToVotesTableMigration.java
+++ b/src/main/java/com/avairebot/database/migrate/migrations/AddSelectedBackgroundToVotesTableMigration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.database.migrate.migrations;
+
+import com.avairebot.Constants;
+import com.avairebot.contracts.database.migrations.Migration;
+import com.avairebot.database.schema.Schema;
+
+import java.sql.SQLException;
+
+public class AddSelectedBackgroundToVotesTableMigration implements Migration {
+
+    @Override
+    public String created_at() {
+        return "Sat, Jan 26, 2019 12:10 PM";
+    }
+
+    @Override
+    public boolean up(Schema schema) throws SQLException {
+        if (schema.hasColumn(Constants.VOTES_TABLE_NAME, "selected_bg")) {
+            return true;
+        }
+
+        schema.getDbm().queryUpdate(String.format(
+            "ALTER TABLE `%s` ADD `selected_bg` INT NULL DEFAULT NULL;",
+            Constants.VOTES_TABLE_NAME
+        ));
+
+        return true;
+    }
+
+    @Override
+    public boolean down(Schema schema) throws SQLException {
+        if (!schema.hasColumn(Constants.VOTES_TABLE_NAME, "selected_bg")) {
+            return true;
+        }
+
+        schema.getDbm().queryUpdate(String.format(
+            "ALTER TABLE `%s` DROP `selected_bg`;",
+            Constants.GUILD_TABLE_NAME
+        ));
+
+        return true;
+    }
+}

--- a/src/main/java/com/avairebot/database/migrate/migrations/CreatePurchasesTableMigration.java
+++ b/src/main/java/com/avairebot/database/migrate/migrations/CreatePurchasesTableMigration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.database.migrate.migrations;
+
+import com.avairebot.Constants;
+import com.avairebot.contracts.database.migrations.Migration;
+import com.avairebot.database.schema.Schema;
+
+import java.sql.SQLException;
+
+public class CreatePurchasesTableMigration implements Migration {
+
+    @Override
+    public String created_at() {
+        return "Sat, Jan 19, 2019 12:16 PM";
+    }
+
+    @Override
+    public boolean up(Schema schema) throws SQLException {
+        return schema.createIfNotExists(Constants.PURCHASES_TABLE_NAME, table -> {
+            table.Increments("id");
+            table.Long("user_id");
+            table.String("type");
+            table.Integer("type_id");
+            table.Timestamps();
+        });
+    }
+
+    @Override
+    public boolean down(Schema schema) throws SQLException {
+        return schema.dropIfExists(Constants.PURCHASES_TABLE_NAME);
+    }
+}

--- a/src/main/java/com/avairebot/database/transformers/PlayerTransformer.java
+++ b/src/main/java/com/avairebot/database/transformers/PlayerTransformer.java
@@ -24,7 +24,11 @@ package com.avairebot.database.transformers;
 import com.avairebot.contracts.database.transformers.Transformer;
 import com.avairebot.database.collection.DataRow;
 
+import javax.annotation.Nonnull;
+
 public class PlayerTransformer extends Transformer {
+
+    private static final PurchasesTransformer EMPTY_PURCHASES = new PurchasesTransformer(null);
 
     private final long userId;
     private final long guildId;
@@ -34,6 +38,9 @@ public class PlayerTransformer extends Transformer {
     private String discriminator;
     private String avatarId;
     private long experience = 0;
+
+    private boolean hasPurchases = false;
+    private PurchasesTransformer purchases = EMPTY_PURCHASES;
 
     public PlayerTransformer(long userId, long guildId, DataRow data) {
         super(data);
@@ -47,6 +54,7 @@ public class PlayerTransformer extends Transformer {
             discriminator = data.getString("discriminator");
             avatarId = data.getString("avatar");
             experience = data.getLong("experience", 0);
+            hasPurchases = data.getInt("purchases", 0) > 0;
         }
 
         reset();
@@ -94,5 +102,26 @@ public class PlayerTransformer extends Transformer {
 
     public void incrementExperienceBy(int amount) {
         experience = experience + amount;
+    }
+
+    public boolean hasPurchases() {
+        return hasPurchases;
+    }
+
+    @Nonnull
+    public PurchasesTransformer getPurchases() {
+        return purchases;
+    }
+
+    public void setPurchases(@Nonnull PurchasesTransformer purchases) {
+        this.purchases = purchases;
+    }
+
+    @Override
+    protected boolean checkIfTransformerHasData() {
+        return data != null
+            && data.getString("username") != null
+            && data.getString("experience") != null
+            && data.getString("discriminator") != null;
     }
 }

--- a/src/main/java/com/avairebot/database/transformers/PurchasesTransformer.java
+++ b/src/main/java/com/avairebot/database/transformers/PurchasesTransformer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.database.transformers;
+
+import com.avairebot.contracts.database.transformers.Transformer;
+import com.avairebot.database.collection.Collection;
+import com.avairebot.database.collection.DataRow;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.*;
+
+public class PurchasesTransformer extends Transformer {
+
+    private static final Map<String, Set<Integer>> emptyPurchases = new HashMap<>();
+
+    private Map<String, Set<Integer>> purchases = emptyPurchases;
+
+    public PurchasesTransformer(Collection collection) {
+        super(null);
+
+        if (collection != null && !collection.isEmpty()) {
+            Map<String, Set<Integer>> purchases = new HashMap<>();
+            for (DataRow row : collection) {
+                if (row == null || row.getString("type") == null || row.getString("type_id") == null) {
+                    continue;
+                }
+
+                String type = row.getString("type").toLowerCase();
+                int typeId = row.getInt("type_id");
+
+                if (!purchases.containsKey(type)) {
+                    purchases.put(type, new HashSet<>());
+                }
+
+                purchases.get(type).add(typeId);
+            }
+            this.purchases = Collections.unmodifiableMap(purchases);
+        }
+    }
+
+    @Nonnull
+    public Map<String, Set<Integer>> getPurchases() {
+        return purchases;
+    }
+
+    @Nullable
+    public Set<Integer> getPurchasesFromType(String type) {
+        return purchases.getOrDefault(type, null);
+    }
+
+    public boolean hasPuraches(String type, int id) {
+        return purchases.containsKey(type)
+            && purchases.get(type).contains(id);
+    }
+}

--- a/src/main/java/com/avairebot/database/transformers/PurchasesTransformer.java
+++ b/src/main/java/com/avairebot/database/transformers/PurchasesTransformer.java
@@ -63,16 +63,39 @@ public class PurchasesTransformer extends Transformer {
         }
     }
 
+    /**
+     * Gets the purchases for the player instance, where the key
+     * is the purchase type identifier, and the value is a set
+     * of purchase IDs.
+     *
+     * @return A map of purchases for the player.
+     */
     @Nonnull
     public Map<String, Set<PurchasesId>> getPurchases() {
         return purchases;
     }
 
+    /**
+     * Gets the purchases for the given purchase type.
+     *
+     * @param type The type of purchases that should be returned.
+     * @return Possible-null, a set of purchase IDs belonging to the given type, or
+     * {@code NULL} if no purchases with the given ID was found for the player.
+     */
     @Nullable
     public Set<PurchasesId> getPurchasesFromType(String type) {
         return purchases.getOrDefault(type, null);
     }
 
+    /**
+     * Gets the selected purchase type ID for the give type, if the player
+     * doesn't have any purchases of the given type, of if the player
+     * doesn't have a purchase of the given type selected, the
+     * method will return {@code NULL}.
+     *
+     * @param type The name of the purchase type.
+     * @return Possibly-null, the selected purchase type ID, or {@code NULL}.
+     */
     @Nullable
     public Integer getSelectedPurchasesForType(String type) {
         Set<PurchasesId> purchases = getPurchasesFromType(type);
@@ -89,7 +112,14 @@ public class PurchasesTransformer extends Transformer {
         return null;
     }
 
-    @SuppressWarnings("SuspiciousMethodCalls")
+    /**
+     * Checks if the player has a purchase of the given type and type ID.
+     *
+     * @param type The type that should be checked for.
+     * @param id   The ID that should belong to the type.
+     * @return {@code True} if the player has a purchase belonging to
+     * the given type with the given ID, {@code False} otherwise.
+     */
     public boolean hasPurchase(String type, int id) {
         if (!purchases.containsKey(type)) {
             return false;
@@ -114,10 +144,21 @@ public class PurchasesTransformer extends Transformer {
             this.selected = selected;
         }
 
+        /**
+         * The ID of the purchase, this is not the incrementing purchase
+         * ID in the database, but the static ID of the purchased item.
+         *
+         * @return The ID of the purchase.
+         */
         public int getId() {
             return id;
         }
 
+        /**
+         * Determines if the purchase is selected by the player or not.
+         *
+         * @return {@code True} if the purchase is selected, {@code False} otherwise.
+         */
         public boolean isSelected() {
             return selected;
         }

--- a/src/main/java/com/avairebot/database/transformers/PurchasesTransformer.java
+++ b/src/main/java/com/avairebot/database/transformers/PurchasesTransformer.java
@@ -80,9 +80,9 @@ public class PurchasesTransformer extends Transformer {
             return null;
         }
 
-        for (PurchasesId id : purchases) {
-            if (id.isSelected()) {
-                return id.getId();
+        for (PurchasesId item : purchases) {
+            if (item.isSelected()) {
+                return item.getId();
             }
         }
 
@@ -91,8 +91,17 @@ public class PurchasesTransformer extends Transformer {
 
     @SuppressWarnings("SuspiciousMethodCalls")
     public boolean hasPurchase(String type, int id) {
-        return purchases.containsKey(type)
-            && purchases.get(type).contains(id);
+        if (!purchases.containsKey(type)) {
+            return false;
+        }
+
+        for (PurchasesId item : purchases.get(type)) {
+            if (item.getId() == id) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public class PurchasesId {

--- a/src/main/java/com/avairebot/imagegen/RankBackgrounds.java
+++ b/src/main/java/com/avairebot/imagegen/RankBackgrounds.java
@@ -22,13 +22,15 @@
 package com.avairebot.imagegen;
 
 import com.avairebot.contracts.imagegen.BackgroundRankColors;
+import com.avairebot.contracts.shop.PurchaseType;
 import com.avairebot.imagegen.colors.ranks.*;
 import com.avairebot.shared.ExitCodes;
 
+import javax.annotation.Nonnull;
 import java.lang.reflect.InvocationTargetException;
 import java.util.EnumMap;
 
-public enum RankBackgrounds {
+public enum RankBackgrounds implements PurchaseType {
 
     DISCORD_DARK(0, null, DiscordDarkColors.class),
     DISCORD_LIGHT(1, null, DiscordLightColors.class),
@@ -103,5 +105,11 @@ public enum RankBackgrounds {
      */
     public BackgroundRankColors getBackgroundColors() {
         return backgroundColors.get(this);
+    }
+
+    @Nonnull
+    @Override
+    public String getPurchaseType() {
+        return "rank-background";
     }
 }

--- a/src/main/java/com/avairebot/imagegen/RankBackgrounds.java
+++ b/src/main/java/com/avairebot/imagegen/RankBackgrounds.java
@@ -35,11 +35,11 @@ import java.util.Set;
 
 public enum RankBackgrounds implements PurchaseType {
 
-    DISCORD_DARK(0, "Discord Dark Theme", null, DiscordDarkColors.class),
-    DISCORD_LIGHT(1, "Discord Light Theme", null, DiscordLightColors.class),
-    PURPLE(2, "Purple", null, PurpleColors.class),
-    PIKACHU(10, "Pikachu", "pikachu.jpg", PikachuColors.class),
-    MOUNTAIN_RANGE(11, "Mountain Range", "mountain-range.jpg", MountainRangeColors.class);
+    DISCORD_DARK(0, 20, "Discord Dark Theme", null, DiscordDarkColors.class),
+    DISCORD_LIGHT(1, 20, "Discord Light Theme", null, DiscordLightColors.class),
+    PURPLE(2, 10, "Purple", null, PurpleColors.class),
+    PIKACHU(10, 50, "Pikachu", "pikachu.jpg", PikachuColors.class),
+    MOUNTAIN_RANGE(11, 50, "Mountain Range", "mountain-range.jpg", MountainRangeColors.class);
 
     private static final RankBackgrounds DEFAULT_BACKGROUND = RankBackgrounds.PURPLE;
     private static final EnumMap<RankBackgrounds, BackgroundRankColors> backgroundColors = new EnumMap<>(RankBackgrounds.class);
@@ -58,12 +58,14 @@ public enum RankBackgrounds implements PurchaseType {
     }
 
     private final int id;
+    private final int cost;
     private final String name;
     private final String file;
     private final Class<? extends BackgroundRankColors> instance;
 
-    RankBackgrounds(int id, String name, String file, Class<? extends BackgroundRankColors> instance) {
+    RankBackgrounds(int id, int cost, String name, String file, Class<? extends BackgroundRankColors> instance) {
         this.id = id;
+        this.cost = cost;
         this.name = name;
         this.file = file;
         this.instance = instance;
@@ -130,6 +132,11 @@ public enum RankBackgrounds implements PurchaseType {
      */
     public BackgroundRankColors getBackgroundColors() {
         return backgroundColors.get(this);
+    }
+
+    @Override
+    public int getCost() {
+        return cost;
     }
 
     @Nonnull

--- a/src/main/java/com/avairebot/imagegen/RankBackgrounds.java
+++ b/src/main/java/com/avairebot/imagegen/RankBackgrounds.java
@@ -30,21 +30,25 @@ import com.avairebot.shared.ExitCodes;
 import javax.annotation.Nonnull;
 import java.lang.reflect.InvocationTargetException;
 import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.Set;
 
 public enum RankBackgrounds implements PurchaseType {
 
-    DISCORD_DARK(0, null, DiscordDarkColors.class),
-    DISCORD_LIGHT(1, null, DiscordLightColors.class),
-    PURPLE(2, null, PurpleColors.class),
-    PIKACHU(10, "pikachu.jpg", PikachuColors.class),
-    MAUNTAIN_RANGE(11, "mountain-range.jpg", MountainRangeColors.class);
+    DISCORD_DARK(0, "Discord Dark Theme", null, DiscordDarkColors.class),
+    DISCORD_LIGHT(1, "Discord Light Theme", null, DiscordLightColors.class),
+    PURPLE(2, "Purple", null, PurpleColors.class),
+    PIKACHU(10, "Pikachu", "pikachu.jpg", PikachuColors.class),
+    MOUNTAIN_RANGE(11, "Mountain Range", "mountain-range.jpg", MountainRangeColors.class);
 
     private static final RankBackgrounds DEFAULT_BACKGROUND = RankBackgrounds.PURPLE;
     private static final EnumMap<RankBackgrounds, BackgroundRankColors> backgroundColors = new EnumMap<>(RankBackgrounds.class);
+    private static final Set<String> names = new HashSet<>();
 
     static {
         for (RankBackgrounds type : values()) {
             try {
+                names.add(type.getName());
                 backgroundColors.put(type, type.getClassInstance().getDeclaredConstructor().newInstance());
             } catch (InstantiationException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
                 System.out.printf("Invalid cache type given: %s", e.getMessage());
@@ -54,11 +58,13 @@ public enum RankBackgrounds implements PurchaseType {
     }
 
     private final int id;
+    private final String name;
     private final String file;
     private final Class<? extends BackgroundRankColors> instance;
 
-    RankBackgrounds(int id, String file, Class<? extends BackgroundRankColors> instance) {
+    RankBackgrounds(int id, String name, String file, Class<? extends BackgroundRankColors> instance) {
         this.id = id;
+        this.name = name;
         this.file = file;
         this.instance = instance;
     }
@@ -73,12 +79,30 @@ public enum RankBackgrounds implements PurchaseType {
     }
 
     /**
+     * Gets the names of all the rank backgrounds.
+     *
+     * @return A set of all the rank background names.
+     */
+    public static Set<String> getNames() {
+        return names;
+    }
+
+    /**
      * Gets the ID for the image, can be used as a reference in the database.
      *
      * @return The image ID.
      */
     public int getId() {
         return id;
+    }
+
+    /**
+     * Gets the name of the rank background.
+     *
+     * @return The name of the rank background.
+     */
+    public String getName() {
+        return name;
     }
 
     /**

--- a/src/main/java/com/avairebot/imagegen/RankBackgrounds.java
+++ b/src/main/java/com/avairebot/imagegen/RankBackgrounds.java
@@ -115,6 +115,13 @@ public enum RankBackgrounds implements PurchaseType {
         return null;
     }
 
+    /**
+     * Gets the rank background with the given ID, if no rank backgrounds were
+     * found with the given ID, {@code NULL} will be returned instead.
+     *
+     * @param backgroundId The ID of the rank background that should be returned.
+     * @return Possibly-null, the rank background with a matching ID, or {@code NULL}.
+     */
     @Nullable
     public static RankBackgrounds fromId(int backgroundId) {
         for (RankBackgrounds background : values()) {

--- a/src/main/java/com/avairebot/imagegen/RankBackgrounds.java
+++ b/src/main/java/com/avairebot/imagegen/RankBackgrounds.java
@@ -62,10 +62,7 @@ public enum RankBackgrounds implements PurchaseType {
 
         unsortedNamesToCost.entrySet().stream()
             .sorted(Map.Entry.comparingByValue())
-            .forEach(entry -> {
-                System.out.println(entry.getKey() + " :: " + entry.getValue());
-                namesToCost.put(entry.getKey(), entry.getValue());
-            });
+            .forEach(entry -> namesToCost.put(entry.getKey(), entry.getValue()));
     }
 
     private final int id;

--- a/src/main/java/com/avairebot/imagegen/RankBackgrounds.java
+++ b/src/main/java/com/avairebot/imagegen/RankBackgrounds.java
@@ -21,6 +21,7 @@
 
 package com.avairebot.imagegen;
 
+import com.avairebot.Constants;
 import com.avairebot.contracts.imagegen.BackgroundRankColors;
 import com.avairebot.contracts.shop.PurchaseType;
 import com.avairebot.imagegen.colors.ranks.*;
@@ -110,6 +111,6 @@ public enum RankBackgrounds implements PurchaseType {
     @Nonnull
     @Override
     public String getPurchaseType() {
-        return "rank-background";
+        return Constants.RANK_BACKGROUND_PURCHASE_TYPE;
     }
 }

--- a/src/main/java/com/avairebot/imagegen/RankBackgrounds.java
+++ b/src/main/java/com/avairebot/imagegen/RankBackgrounds.java
@@ -115,6 +115,16 @@ public enum RankBackgrounds implements PurchaseType {
         return null;
     }
 
+    @Nullable
+    public static RankBackgrounds fromId(int backgroundId) {
+        for (RankBackgrounds background : values()) {
+            if (background.getId() == backgroundId) {
+                return background;
+            }
+        }
+        return null;
+    }
+
     /**
      * Gets the ID for the image, can be used as a reference in the database.
      *

--- a/src/main/resources/langs/da_DK.yml
+++ b/src/main/resources/langs/da_DK.yml
@@ -713,6 +713,25 @@ utility:
             10000: 'det her giver ingen mening :thinking: #BlameAlexis'
             other: 'langsom af. :dizzy_face:'
 
+    RankBackgroundCommand:
+        canBeUnlocked: "Rank backgrounds can be unlocked using **[Vote Points](https://discordbots.org/bot/avaire)**,\nyou'll get **1 point** each time you vote for the bot."
+        listTitle: "Rank Backgrounds ({0})"
+        youHaveVotePoints: "You have {0} vote points."
+        exampleTitle: "{0} Example"
+        exampleFooter: "{0} costs {1} vote points"
+        alreadyOwnsBackground: "You already own the **:name** background!"
+        doesntHaveEnoughPoints: "You don't have enough vote points to buy this background, the background costs `{0}`, and you have `{1}` vote points."
+        boughtBackgroundSuccessfully: "Congratulation! You now own the **:name** background!\nYou can use the `:command` command to use the background."
+        youDontOwnThisBackground: "You don't own the **:name** background, however you can buy it for **:cost** Vote Points!"
+        successfullyChangedBackground: "You have successfully changed to use the **:name** background."
+        disabledBackgrounds: "Rank backgrounds have successfully been disabled, you are now using embedded messages for rank commands again."
+        buyNotes:
+            alreadyOwns: "**{0}**\n- _You already own this background._"
+            doesntOwns: "**{0}**\n - Costs {1} vote points."
+        failedToSendExampleMessage: "Something went wrong while trying to send the example image for the {0} background, error: {1}."
+        failedToBuyTheBackground: "Something went wrong while buying the background, error: {0}"
+        failedToSetBackground: "Failed to set the background due to a database error, try again later, if this error continues to appear, please contact one of my developers."
+
     RankCommand:
         botsCannotReceiveXp: "Bots kan ikke modtage xp og kan derfor ikke rangeres, prøv at tagge en bruger i stedet."
         unranked: 'Unranked'

--- a/src/main/resources/langs/de_DE.yml
+++ b/src/main/resources/langs/de_DE.yml
@@ -715,6 +715,25 @@ utility:
             10000: 'Das macht keinen Sinn. :thinking: #BlameAlexis'
             other: 'Einfach nur zu langsam. :dizzy_face:'
 
+    RankBackgroundCommand:
+        canBeUnlocked: "Rank backgrounds can be unlocked using **[Vote Points](https://discordbots.org/bot/avaire)**,\nyou'll get **1 point** each time you vote for the bot."
+        listTitle: "Rank Backgrounds ({0})"
+        youHaveVotePoints: "You have {0} vote points."
+        exampleTitle: "{0} Example"
+        exampleFooter: "{0} costs {1} vote points"
+        alreadyOwnsBackground: "You already own the **:name** background!"
+        doesntHaveEnoughPoints: "You don't have enough vote points to buy this background, the background costs `{0}`, and you have `{1}` vote points."
+        boughtBackgroundSuccessfully: "Congratulation! You now own the **:name** background!\nYou can use the `:command` command to use the background."
+        youDontOwnThisBackground: "You don't own the **:name** background, however you can buy it for **:cost** Vote Points!"
+        successfullyChangedBackground: "You have successfully changed to use the **:name** background."
+        disabledBackgrounds: "Rank backgrounds have successfully been disabled, you are now using embedded messages for rank commands again."
+        buyNotes:
+            alreadyOwns: "**{0}**\n- _You already own this background._"
+            doesntOwns: "**{0}**\n - Costs {1} vote points."
+        failedToSendExampleMessage: "Something went wrong while trying to send the example image for the {0} background, error: {1}."
+        failedToBuyTheBackground: "Something went wrong while buying the background, error: {0}"
+        failedToSetBackground: "Failed to set the background due to a database error, try again later, if this error continues to appear, please contact one of my developers."
+
     RankCommand:
         botsCannotReceiveXp: "Bot's können keine XP erhalten und sind auch nicht in der Lage einen Rang zu erhalten. Versuche stattdessen einen User zu taggen."
         unranked: 'Kein Rang'

--- a/src/main/resources/langs/en_PT.yml
+++ b/src/main/resources/langs/en_PT.yml
@@ -714,6 +714,25 @@ utility:
             10000: 'this makes no sense :thinking: #BlameAlexis'
             other: 'slow af. :dizzy_face:'
 
+    RankBackgroundCommand:
+        canBeUnlocked: "Rank backgrounds can be unlocked using **[Vote Points](https://discordbots.org/bot/avaire)**,\nyou'll get **1 point** each time you vote for the bot."
+        listTitle: "Rank Backgrounds ({0})"
+        youHaveVotePoints: "You have {0} vote points."
+        exampleTitle: "{0} Example"
+        exampleFooter: "{0} costs {1} vote points"
+        alreadyOwnsBackground: "You already own the **:name** background!"
+        doesntHaveEnoughPoints: "You don't have enough vote points to buy this background, the background costs `{0}`, and you have `{1}` vote points."
+        boughtBackgroundSuccessfully: "Congratulation! You now own the **:name** background!\nYou can use the `:command` command to use the background."
+        youDontOwnThisBackground: "You don't own the **:name** background, however you can buy it for **:cost** Vote Points!"
+        successfullyChangedBackground: "You have successfully changed to use the **:name** background."
+        disabledBackgrounds: "Rank backgrounds have successfully been disabled, you are now using embedded messages for rank commands again."
+        buyNotes:
+            alreadyOwns: "**{0}**\n- _You already own this background._"
+            doesntOwns: "**{0}**\n - Costs {1} vote points."
+        failedToSendExampleMessage: "Something went wrong while trying to send the example image for the {0} background, error: {1}."
+        failedToBuyTheBackground: "Something went wrong while buying the background, error: {0}"
+        failedToSetBackground: "Failed to set the background due to a database error, try again later, if this error continues to appear, please contact one of my developers."
+
     RankCommand:
         botsCannotReceiveXp: "Bots cannot receive xp and therefore can't be ranked, try and tag a user instead."
         unranked: 'Unranked'

--- a/src/main/resources/langs/en_US.yml
+++ b/src/main/resources/langs/en_US.yml
@@ -713,6 +713,25 @@ utility:
             10000: 'this makes no sense :thinking: #BlameAlexis'
             other: 'slow af. :dizzy_face:'
 
+    RankBackgroundCommand:
+        canBeUnlocked: "Rank backgrounds can be unlocked using **[Vote Points](https://discordbots.org/bot/avaire)**,\nyou'll get **1 point** each time you vote for the bot."
+        listTitle: "Rank Backgrounds ({0})"
+        youHaveVotePoints: "You have {0} vote points."
+        exampleTitle: "{0} Example"
+        exampleFooter: "{0} costs {1} vote points"
+        alreadyOwnsBackground: "You already own the **:name** background!"
+        doesntHaveEnoughPoints: "You don't have enough vote points to buy this background, the background costs `{0}`, and you have `{1}` vote points."
+        boughtBackgroundSuccessfully: "Congratulation! You now own the **:name** background!\nYou can use the `:command` command to use the background."
+        youDontOwnThisBackground: "You don't own the **:name** background, however you can buy it for **:cost** Vote Points!"
+        successfullyChangedBackground: "You have successfully changed to use the **:name** background."
+        disabledBackgrounds: "Rank backgrounds have successfully been disabled, you are now using embedded messages for rank commands again."
+        buyNotes:
+            alreadyOwns: "**{0}**\n- _You already own this background._"
+            doesntOwns: "**{0}**\n - Costs {1} vote points."
+        failedToSendExampleMessage: "Something went wrong while trying to send the example image for the {0} background, error: {1}."
+        failedToBuyTheBackground: "Something went wrong while buying the background, error: {0}"
+        failedToSetBackground: "Failed to set the background due to a database error, try again later, if this error continues to appear, please contact one of my developers."
+
     RankCommand:
         botsCannotReceiveXp: "Bots cannot receive xp and therefore can't be ranked, try and tag a user instead."
         unranked: 'Unranked'

--- a/src/main/resources/langs/es_ES.yml
+++ b/src/main/resources/langs/es_ES.yml
@@ -714,6 +714,25 @@ utility:
             10000: 'esto no tiene sentido :thinking: #AlexisCulpable'
             other: 'j*didamente lento. :dizzy_face:'
 
+    RankBackgroundCommand:
+        canBeUnlocked: "Rank backgrounds can be unlocked using **[Vote Points](https://discordbots.org/bot/avaire)**,\nyou'll get **1 point** each time you vote for the bot."
+        listTitle: "Rank Backgrounds ({0})"
+        youHaveVotePoints: "You have {0} vote points."
+        exampleTitle: "{0} Example"
+        exampleFooter: "{0} costs {1} vote points"
+        alreadyOwnsBackground: "You already own the **:name** background!"
+        doesntHaveEnoughPoints: "You don't have enough vote points to buy this background, the background costs `{0}`, and you have `{1}` vote points."
+        boughtBackgroundSuccessfully: "Congratulation! You now own the **:name** background!\nYou can use the `:command` command to use the background."
+        youDontOwnThisBackground: "You don't own the **:name** background, however you can buy it for **:cost** Vote Points!"
+        successfullyChangedBackground: "You have successfully changed to use the **:name** background."
+        disabledBackgrounds: "Rank backgrounds have successfully been disabled, you are now using embedded messages for rank commands again."
+        buyNotes:
+            alreadyOwns: "**{0}**\n- _You already own this background._"
+            doesntOwns: "**{0}**\n - Costs {1} vote points."
+        failedToSendExampleMessage: "Something went wrong while trying to send the example image for the {0} background, error: {1}."
+        failedToBuyTheBackground: "Something went wrong while buying the background, error: {0}"
+        failedToSetBackground: "Failed to set the background due to a database error, try again later, if this error continues to appear, please contact one of my developers."
+
     RankCommand:
         botsCannotReceiveXp: "Los bots no pueden obtener EXP, por lo que no tienen clasificación. Etiqueta a un usuario."
         unranked: 'Sin clasificación'

--- a/src/main/resources/langs/fr_FR.yml
+++ b/src/main/resources/langs/fr_FR.yml
@@ -714,6 +714,25 @@ utility:
             10000: "cela n'a aucun sens :thinking: #BlameAlexis"
             other: "lent. :dizzy_face:"
 
+    RankBackgroundCommand:
+        canBeUnlocked: "Rank backgrounds can be unlocked using **[Vote Points](https://discordbots.org/bot/avaire)**,\nyou'll get **1 point** each time you vote for the bot."
+        listTitle: "Rank Backgrounds ({0})"
+        youHaveVotePoints: "You have {0} vote points."
+        exampleTitle: "{0} Example"
+        exampleFooter: "{0} costs {1} vote points"
+        alreadyOwnsBackground: "You already own the **:name** background!"
+        doesntHaveEnoughPoints: "You don't have enough vote points to buy this background, the background costs `{0}`, and you have `{1}` vote points."
+        boughtBackgroundSuccessfully: "Congratulation! You now own the **:name** background!\nYou can use the `:command` command to use the background."
+        youDontOwnThisBackground: "You don't own the **:name** background, however you can buy it for **:cost** Vote Points!"
+        successfullyChangedBackground: "You have successfully changed to use the **:name** background."
+        disabledBackgrounds: "Rank backgrounds have successfully been disabled, you are now using embedded messages for rank commands again."
+        buyNotes:
+            alreadyOwns: "**{0}**\n- _You already own this background._"
+            doesntOwns: "**{0}**\n - Costs {1} vote points."
+        failedToSendExampleMessage: "Something went wrong while trying to send the example image for the {0} background, error: {1}."
+        failedToBuyTheBackground: "Something went wrong while buying the background, error: {0}"
+        failedToSetBackground: "Failed to set the background due to a database error, try again later, if this error continues to appear, please contact one of my developers."
+
     RankCommand:
         botsCannotReceiveXp: "Les Bots ne peuvent pas recevoir d'xp et donc être classé, essaye plutôt d'identifier un utilisateur."
         unranked: "Non classé"

--- a/src/main/resources/langs/hu_HU.yml
+++ b/src/main/resources/langs/hu_HU.yml
@@ -720,6 +720,25 @@ utility:
             10000: 'ennek semmi értelme :thinking: #BlameAlexis'
             other: 'lassú mint a sz. :dizzy_face:'
 
+    RankBackgroundCommand:
+        canBeUnlocked: "Rank backgrounds can be unlocked using **[Vote Points](https://discordbots.org/bot/avaire)**,\nyou'll get **1 point** each time you vote for the bot."
+        listTitle: "Rank Backgrounds ({0})"
+        youHaveVotePoints: "You have {0} vote points."
+        exampleTitle: "{0} Example"
+        exampleFooter: "{0} costs {1} vote points"
+        alreadyOwnsBackground: "You already own the **:name** background!"
+        doesntHaveEnoughPoints: "You don't have enough vote points to buy this background, the background costs `{0}`, and you have `{1}` vote points."
+        boughtBackgroundSuccessfully: "Congratulation! You now own the **:name** background!\nYou can use the `:command` command to use the background."
+        youDontOwnThisBackground: "You don't own the **:name** background, however you can buy it for **:cost** Vote Points!"
+        successfullyChangedBackground: "You have successfully changed to use the **:name** background."
+        disabledBackgrounds: "Rank backgrounds have successfully been disabled, you are now using embedded messages for rank commands again."
+        buyNotes:
+            alreadyOwns: "**{0}**\n- _You already own this background._"
+            doesntOwns: "**{0}**\n - Costs {1} vote points."
+        failedToSendExampleMessage: "Something went wrong while trying to send the example image for the {0} background, error: {1}."
+        failedToBuyTheBackground: "Something went wrong while buying the background, error: {0}"
+        failedToSetBackground: "Failed to set the background due to a database error, try again later, if this error continues to appear, please contact one of my developers."
+
     RankCommand:
         botsCannotReceiveXp: "A botok nem tudnak tapasztalatot szerezni, ezért nem lehet őket rangsorolni, próbálj meg egy felhasználót inkább."
         unranked: 'Nem rangsorolt'

--- a/src/main/resources/langs/it_IT.yml
+++ b/src/main/resources/langs/it_IT.yml
@@ -713,6 +713,25 @@ utility:
             10000: 'non ha senso :thinking: #BlameAlexis'
             other: 'slow af. :dizzy_face:'
 
+    RankBackgroundCommand:
+        canBeUnlocked: "Rank backgrounds can be unlocked using **[Vote Points](https://discordbots.org/bot/avaire)**,\nyou'll get **1 point** each time you vote for the bot."
+        listTitle: "Rank Backgrounds ({0})"
+        youHaveVotePoints: "You have {0} vote points."
+        exampleTitle: "{0} Example"
+        exampleFooter: "{0} costs {1} vote points"
+        alreadyOwnsBackground: "You already own the **:name** background!"
+        doesntHaveEnoughPoints: "You don't have enough vote points to buy this background, the background costs `{0}`, and you have `{1}` vote points."
+        boughtBackgroundSuccessfully: "Congratulation! You now own the **:name** background!\nYou can use the `:command` command to use the background."
+        youDontOwnThisBackground: "You don't own the **:name** background, however you can buy it for **:cost** Vote Points!"
+        successfullyChangedBackground: "You have successfully changed to use the **:name** background."
+        disabledBackgrounds: "Rank backgrounds have successfully been disabled, you are now using embedded messages for rank commands again."
+        buyNotes:
+            alreadyOwns: "**{0}**\n- _You already own this background._"
+            doesntOwns: "**{0}**\n - Costs {1} vote points."
+        failedToSendExampleMessage: "Something went wrong while trying to send the example image for the {0} background, error: {1}."
+        failedToBuyTheBackground: "Something went wrong while buying the background, error: {0}"
+        failedToSetBackground: "Failed to set the background due to a database error, try again later, if this error continues to appear, please contact one of my developers."
+
     RankCommand:
         botsCannotReceiveXp: "I bot non possono ricevere xp e quindi non possono essere classificati, prova a taggare un utente."
         unranked: 'Non classificato'

--- a/src/main/resources/langs/no_NB.yml
+++ b/src/main/resources/langs/no_NB.yml
@@ -713,6 +713,25 @@ utility:
             10000: 'dette gir ingen mening :thinking: #BlameAlexis'
             other: 'tregt som faen. :dizzy_face:'
 
+    RankBackgroundCommand:
+        canBeUnlocked: "Rank backgrounds can be unlocked using **[Vote Points](https://discordbots.org/bot/avaire)**,\nyou'll get **1 point** each time you vote for the bot."
+        listTitle: "Rank Backgrounds ({0})"
+        youHaveVotePoints: "You have {0} vote points."
+        exampleTitle: "{0} Example"
+        exampleFooter: "{0} costs {1} vote points"
+        alreadyOwnsBackground: "You already own the **:name** background!"
+        doesntHaveEnoughPoints: "You don't have enough vote points to buy this background, the background costs `{0}`, and you have `{1}` vote points."
+        boughtBackgroundSuccessfully: "Congratulation! You now own the **:name** background!\nYou can use the `:command` command to use the background."
+        youDontOwnThisBackground: "You don't own the **:name** background, however you can buy it for **:cost** Vote Points!"
+        successfullyChangedBackground: "You have successfully changed to use the **:name** background."
+        disabledBackgrounds: "Rank backgrounds have successfully been disabled, you are now using embedded messages for rank commands again."
+        buyNotes:
+            alreadyOwns: "**{0}**\n- _You already own this background._"
+            doesntOwns: "**{0}**\n - Costs {1} vote points."
+        failedToSendExampleMessage: "Something went wrong while trying to send the example image for the {0} background, error: {1}."
+        failedToBuyTheBackground: "Something went wrong while buying the background, error: {0}"
+        failedToSetBackground: "Failed to set the background due to a database error, try again later, if this error continues to appear, please contact one of my developers."
+
     RankCommand:
         botsCannotReceiveXp: "Botter kan ikke motta xp og kan derfor ikke bli rangert, prøv og tagge en bruker istedenfor."
         unranked: 'Urangert'

--- a/src/main/resources/langs/ru_RU.yml
+++ b/src/main/resources/langs/ru_RU.yml
@@ -714,6 +714,25 @@ utility:
             10000: 'это не имеет никакого смысла :thinking: #BlameAlexis'
             other: 'медленный АФК. :dizzy_face:'
 
+    RankBackgroundCommand:
+        canBeUnlocked: "Rank backgrounds can be unlocked using **[Vote Points](https://discordbots.org/bot/avaire)**,\nyou'll get **1 point** each time you vote for the bot."
+        listTitle: "Rank Backgrounds ({0})"
+        youHaveVotePoints: "You have {0} vote points."
+        exampleTitle: "{0} Example"
+        exampleFooter: "{0} costs {1} vote points"
+        alreadyOwnsBackground: "You already own the **:name** background!"
+        doesntHaveEnoughPoints: "You don't have enough vote points to buy this background, the background costs `{0}`, and you have `{1}` vote points."
+        boughtBackgroundSuccessfully: "Congratulation! You now own the **:name** background!\nYou can use the `:command` command to use the background."
+        youDontOwnThisBackground: "You don't own the **:name** background, however you can buy it for **:cost** Vote Points!"
+        successfullyChangedBackground: "You have successfully changed to use the **:name** background."
+        disabledBackgrounds: "Rank backgrounds have successfully been disabled, you are now using embedded messages for rank commands again."
+        buyNotes:
+            alreadyOwns: "**{0}**\n- _You already own this background._"
+            doesntOwns: "**{0}**\n - Costs {1} vote points."
+        failedToSendExampleMessage: "Something went wrong while trying to send the example image for the {0} background, error: {1}."
+        failedToBuyTheBackground: "Something went wrong while buying the background, error: {0}"
+        failedToSetBackground: "Failed to set the background due to a database error, try again later, if this error continues to appear, please contact one of my developers."
+
     RankCommand:
         botsCannotReceiveXp: "Боты не могут получать XP и, следовательно, не могут быть ранжированы, попробуйте вместо этого пометить пользователя."
         unranked: 'Неоцениваемый'


### PR DESCRIPTION
This PR adds the ability for users to select a background that should be should be used instead of the default embed rank message, users can unlock/buy the backgrounds using _Vote Points_, users can also freely swap between backgrounds they have bought before, and the backgrounds will be used on all servers they're on.

There are a few things that need to be done before the feature can be considered complete.

### TODO

- [x] **Add support for listing backgrounds.**
- [x] **Add support for displaying an example of a background.**<br>This is used so people can see an example of how the background looks before they buy it.
   - > Changing how the backgrounds are displayed to the user might still be a good idea so it looks a bit nicer, but the functionality itself is there and works.
- [x] **Add support for buying a background.**<br>This should only require checking if the user actually has enough vote points to buy the background, then inserting a new record into the `purchases` table, and then clearing the users player controller cache.
   - [ ] **Mark the bought background as the select background for the user.**
- [x] **Add support for selecting a background.**<br>This would require a new database migration, all that's pretty much required is some ID linking the users selected background to either the background ID(Which is currently stored in an enum), or the purchase ID, which will hold both the type(`rank-background`), and the ID for the background.
- [x] **Change the `!rank` command to use the image instead of embed if the user has one selected.**<br>The embed message should still be used if the user doesn't have a background selected, the embed message can also be used as a fallback in case rendering the image fails for some reason.
- [x] **Last Minute TODOs.**
  - [x] Format all the code to follow the code style.
  - [x] Add documentation to any contracts or public API methods.
  - [x] Move all messages into the language files.
  - [x] Add/fix error messages to be more coherent and easier to understand.
  - [x] Finish usage & example instructions, and the description.