### PR TITLE
Add proxy API and website build instructions for Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: java -jar AvaIre.jar --no-colors -env
+web: vendor/bin/heroku-php-apache2 -C avairebotapache2.conf public/ & java -jar AvaIre.jar --no-colors -env
 worker: java -jar AvaIre.jar --no-colors -env

--- a/app.json
+++ b/app.json
@@ -245,10 +245,12 @@
             "description": "The name of the website upstream repo. If you want to use your own forked avaire website, change this to your situation.",
             "required": false,
             "value": "avaire/website"
+			},
 		"AVAIRE_REPO_GIT": {
             "description": "The name of the AvaIre upstream repo. If you want to use your own repo to set the .git, change this to your situation.",
             "required": false,
             "value": "avaire/avaire"
+			}
     },
     "formation": {
         "worker": {

--- a/app.json
+++ b/app.json
@@ -242,13 +242,13 @@
             "value": "master"
         },
 		"WEBSITE_REPO_GIT": {
-            "description": "The name of the website upstream repo. If you want to use your own forked avaire website, change this to your situation.",
-            "required": false,
+            "description": "The name of the website upstream repo. If you want to use your own forked avaire website, change this to your situation. Required to compile AvaIre.jar.",
+            "required": true,
             "value": "avaire/website"
 			},
 		"AVAIRE_REPO_GIT": {
-            "description": "The name of the AvaIre upstream repo. If you want to use your own repo to set the .git, change this to your situation.",
-            "required": false,
+            "description": "The name of the AvaIre upstream repo. If you want to use your own repo to set the .git, change this to your situation. Required to compile the website.",
+            "required": true,
             "value": "avaire/avaire"
 			}
     },

--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
     "website": "https://avairebot.com/",
     "repository": "https://github.com/avaire/avaire",
     "logo": "https://imgur.com/H8RCD5F.png",
-    "success_url": "/stats",
+    "success_url": "/",
     "addons": [
         {
             "plan": "jawsdb:kitefin"
@@ -240,7 +240,15 @@
             "description": "The branch of the upstream repo, leave this as is for AvaIre",
             "required": false,
             "value": "master"
-        }
+        },
+		"WEBSITE_REPO_GIT": {
+            "description": "The name of the website upstream repo. If you want to use your own forked avaire website, change this to your situation.",
+            "required": false,
+            "value": "avaire/website"
+		"AVAIRE_REPO_GIT": {
+            "description": "The name of the AvaIre upstream repo. If you want to use your own repo to set the .git, change this to your situation.",
+            "required": false,
+            "value": "avaire/avaire"
     },
     "formation": {
         "worker": {

--- a/app.json
+++ b/app.json
@@ -266,6 +266,15 @@
         },
         {
             "url": "https://github.com/weibeld/heroku-buildpack-run"
+        },
+        {
+            "url": "heroku/php"
+        },	
+        {
+            "url": "https://github.com/luo83651896/heroku-buildpack-run"
+        },
+        {
+            "url": "heroku/nodejs"
         }
     ]
 }

--- a/app.json
+++ b/app.json
@@ -131,6 +131,11 @@
             "required": false,
             "value": ""
         },
+		"AVA_WEB_SERVLET_PORT": {
+			"description": "overrides the PORT env variable. Leave as is inorder to access the API with proxy on /avairebotapi/.",
+			"required": false,
+			"value": "8080"
+		},
         "AVA_WEB_SERVLET_METRICS": {
             "description": "Ava uses Prometheus metrics for tracking a long list of different things within the application during runtime, the metrics are then displayed using Grafana to users on a web-dashboard using graphs.",
             "required": false,
@@ -254,13 +259,13 @@
     },
     "buildpacks": [
         {
-            "url": "https://github.com/weibeld/heroku-buildpack-run"
+            "url": "https://github.com/650health/heroku-buildpack-run"
         },
         {
             "url": "heroku/gradle"
         },
         {
-            "url": "https://github.com/650health/heroku-buildpack-run"
+            "url": "https://github.com/weibeld/heroku-buildpack-run"
         }
     ]
 }

--- a/app.json
+++ b/app.json
@@ -240,17 +240,7 @@
             "description": "The branch of the upstream repo, leave this as is for AvaIre",
             "required": false,
             "value": "master"
-        },
-		"WEBSITE_REPO_GIT": {
-            "description": "The name of the website upstream repo. If you want to use your own forked avaire website, change this to your situation. Required to compile AvaIre.jar.",
-            "required": true,
-            "value": "avaire/website"
-			},
-		"AVAIRE_REPO_GIT": {
-            "description": "The name of the AvaIre upstream repo. If you want to use your own repo to set the .git, change this to your situation. Required to compile the website.",
-            "required": true,
-            "value": "avaire/avaire"
-			}
+        }
     },
     "formation": {
         "worker": {

--- a/avairebotapache2.conf
+++ b/avairebotapache2.conf
@@ -1,0 +1,7 @@
+# Gives permission to the user to display what is in these files in a given folder
+DirectoryIndex index.html index.cgi index.pl index.php index.xhtml
+
+# Proxy when accessing /avairebotapi/ to display the content from the internal AvaIrebot
+# /avairebotapi/ access the port defined in: AVA_WEB_SERVLET_PORT.
+ProxyPass "/avairebotapi/" "http://localhost:${AVA_WEB_SERVLET_PORT}/" connectiontimeout=5 timeout=30 keepalive=on
+ProxyPassReverse "/avairebotapi/" "http://localhost:${AVA_WEB_SERVLET_PORT}/"

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -38,6 +38,7 @@ else
   git clone https://github.com/avaire/avaire # Example: avaire/avaire
   mv avaire/.git .
   # Doing this temporarly b/c of system env variables missing
+  mv .env.example .env
   wget -O .env https://pastebin.com/raw/7WwskUtj
 fi
 echo This is the end of the script

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -18,7 +18,7 @@ if [ -d ".git" ]; then
   # Entire /app/ directory is cleared out, to prepare to retrieve the webfiles
   rm -r * & rm -r .git/
   # The website is being cloned and moven out of it's folder
-  git clone https://github.com/$WEBSITE_REPO_GIT # Example: avaire/website
+  git clone https://github.com/avaire/website # Example: avaire/website
   mv website/* .
   rm -r website/
   # Moving the config files needed to run everything back into the original directory
@@ -35,7 +35,7 @@ else
   echo ====== First Part ========
   echo ==========================
   echo First part, set the .git folder.
-  git clone https://github.com/$AVAIRE_REPO_GIT # Example: avaire/avaire
+  git clone https://github.com/avaire/avaire # Example: avaire/avaire
   mv avaire/.git .
   # Doing this temporarly b/c of system env variables missing
   wget -O .env https://pastebin.com/raw/7WwskUtj

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -18,7 +18,7 @@ if [ -d ".git" ]; then
   # Entire /app/ directory is cleared out, to prepare to retrieve the webfiles
   rm -r * & rm -r .git/
   # The website is being cloned and moven out of it's folder
-  git clone "https://github.com/$WEBSITE_REPO_GIT" # Example: avaire/website
+  git clone https://github.com/$WEBSITE_REPO_GIT # Example: avaire/website
   mv website/* .
   rm -r website/
   # Moving the config files needed to run everything back into the original directory
@@ -35,7 +35,7 @@ else
   echo ====== First Part ========
   echo ==========================
   echo First part, set the .git folder.
-  git clone "https://github.com/$AVAIRE_REPO_GIT" # Example: avaire/avaire
+  git clone https://github.com/$AVAIRE_REPO_GIT # Example: avaire/avaire
   mv avaire/.git .
   # Doing this temporarly b/c of system env variables missing
   wget -O .env https://pastebin.com/raw/7WwskUtj

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,5 +1,44 @@
-# This is buildpack-run.sh
-# Trick to clone AvaIre's git into a seperate folder, copying .git to the top directory. Followed by putting the config.yml on the right place.
-rm -rf .git && git clone https://github.com/avaire/avaire.git && cp -r avaire/.git . && cp src/main/resources/config.yml . && cp src/main/resources/constants.yml . && rm -rf avaire/ && echo script worked.
-# Cleaning any build artifacts, done before and after the gradle proces.
-rm -rf build/ && echo cleaned out build artifacts.
+# If AvaIre.jar is compiled
+if [ -d ".git" ]; then
+  # Second step
+  echo ==========================
+  echo ====== Second Part =======
+  echo ==========================
+  echo Moving some files we want to keep after getting the website. We also generate the commandMap.json.
+  echo After getting the website files in the right directory, we move the files back in the right directory with the website files.
+  # Generating the commandMap.json
+  java -jar AvaIre.jar --generate-json-file
+  # Moving the config files needed to run AvaIre.jar and the Apache2 webserver outside the app/ folder
+  mv src/main/resources/config.yml ../config.yml
+  mv src/main/resources/constants.yml ../constants.yml
+  mv AvaIre.jar ../AvaIre.jar
+  mv avairebotapache2.conf ../avairebotapache2.conf
+  mv commandMap.json ../commandMap.json
+  mv Procfile ../Procfile
+  # Entire /app/ directory is cleared out, to prepare to retrieve the webfiles
+  rm -r * & rm -r .git/
+  # The website is being cloned and moven out of it's folder
+  git clone https://github.com/$WEBSITE_REPO_GIT.git # Example: avaire/website
+  mv website/* .
+  rm -r website/
+  # Moving the config files needed to run everything back into the original directory
+  mv ../config.yml .
+  mv ../constants.yml .
+  mv ../AvaIre.jar .
+  mv ../avairebotapache2.conf .
+  mv ../commandMap.json storage/commandMap.json
+  mv ../Procfile . # The Procfile will now override the Procfile from the website repo
+# If AvaIre.jar isn't compiled
+else
+  # First step
+  echo ==========================
+  echo ====== First Part ========
+  echo ==========================
+  echo First part, set the .git folder.
+  git clone https://github.com/$AVAIRE_REPO_GIT.git # Example: avaire/avaire
+  mv avaire/.git .
+  # Doing this temporarly b/c of system env variables missing
+  wget -O .env https://pastebin.com/raw/7WwskUtj
+fi
+echo This is the end of the script
+# The third time the build-run.sh is ran, it won't be this script but the one over at the website repo!

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -18,7 +18,7 @@ if [ -d ".git" ]; then
   # Entire /app/ directory is cleared out, to prepare to retrieve the webfiles
   rm -r * & rm -r .git/
   # The website is being cloned and moven out of it's folder
-  git clone "https://github.com/$WEBSITE_REPO_GIT.git" # Example: avaire/website
+  git clone "https://github.com/$WEBSITE_REPO_GIT" # Example: avaire/website
   mv website/* .
   rm -r website/
   # Moving the config files needed to run everything back into the original directory
@@ -35,7 +35,7 @@ else
   echo ====== First Part ========
   echo ==========================
   echo First part, set the .git folder.
-  git clone "https://github.com/$AVAIRE_REPO_GIT.git" # Example: avaire/avaire
+  git clone "https://github.com/$AVAIRE_REPO_GIT" # Example: avaire/avaire
   mv avaire/.git .
   # Doing this temporarly b/c of system env variables missing
   wget -O .env https://pastebin.com/raw/7WwskUtj

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -18,7 +18,7 @@ if [ -d ".git" ]; then
   # Entire /app/ directory is cleared out, to prepare to retrieve the webfiles
   rm -r * & rm -r .git/
   # The website is being cloned and moven out of it's folder
-  git clone https://github.com/$WEBSITE_REPO_GIT.git # Example: avaire/website
+  git clone "https://github.com/$WEBSITE_REPO_GIT.git" # Example: avaire/website
   mv website/* .
   rm -r website/
   # Moving the config files needed to run everything back into the original directory
@@ -35,7 +35,7 @@ else
   echo ====== First Part ========
   echo ==========================
   echo First part, set the .git folder.
-  git clone https://github.com/$AVAIRE_REPO_GIT.git # Example: avaire/avaire
+  git clone "https://github.com/$AVAIRE_REPO_GIT.git" # Example: avaire/avaire
   mv avaire/.git .
   # Doing this temporarly b/c of system env variables missing
   wget -O .env https://pastebin.com/raw/7WwskUtj


### PR DESCRIPTION
This pull will archieve the following:
### Change the way to compile AvaIre
This pull will also compile the website of AvaIre, incase the user wants to use it with the upcomming dashboard. Therefore compiling AvaIre takes a minute longer but will work just as normal. Expect the API isn't on the root "/" but on a seperate page "/avairebotapi/".

Futhermore, the AVA_WEB_SERVLET_PORT will set the API on 8080 by default, to correctly proxy the API. Changing this is optional and can work withoud changing the apache2 configuration file.

If, users want to have a faster re-build time withoud changing the source, they can use watchdog, as this proces is faster then the traditional AvaIre. This repo will also get a pull with minor improvements like cleaning out leftover files and a updated app.json.

### Cleaner
This pull also properly cleans out all the files, meaning the slug size decreases what improves startup time.

### To-do (after this pull)
Env variables would be great for the website repo, as this would be alot beter then using this temporarly "solution" to get trough the build proces.
```
  # Doing this temporarly b/c of system env variables missing
  mv .env.example .env
```
Ofcours, when the env variables are supported, the above can be removed.

I hope you enjoy this pull, I honestly wasn't sure proxy and Heroku would work out :P 