### PR TITLE
Fix moving website env file for Heroku deployment

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -28,8 +28,6 @@ if [ -d ".git" ]; then
   mv ../avairebotapache2.conf .
   mv ../commandMap.json storage/commandMap.json
   mv ../Procfile . # The Procfile will now override the Procfile from the website repo
-  # Doing this temporarly b/c of system env variables missing
-  mv .env.example .env
 # If AvaIre.jar isn't compiled
 else
   # First step


### PR DESCRIPTION
Moving 
# Doing this temporarly b/c of system env variables missing
  mv .env.example .env
From avaire to website. As this makes more sense and also fixes this repo for heroku.