### PR TITLE
Move hidden file for Heroku buildpack

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,24 +1,7 @@
-if [ -d ".git" ]; then
-  echo Second part, move needed files for AvaIre to parent directory. Clean all other files to keep everything organized.
-  echo When website is cloned and moved into the same directory. Needed files are then placed back in current directory.
-  mv AvaIre.jar ../AvaIre.jar
-  mv avairebotapache2.conf ../avairebotapache2.conf
-  mv Procfile ../Procfile
-  mv update.sh ../update.sh
-  rm -r * & rm -r .git # Entire /app/ directory is cleared out, to prepare to retrieve the webfiles
-  git clone https://github.com/avaire/website # Example: avaire/website
-  mv website/{.[!.],}* .
-  rm -r website/
-  # Moving the config files needed to run everything back into the original directory
-  mv ../AvaIre.jar .
-  java -jar AvaIre.jar
-  java -jar AvaIre.jar --generate-json-file
-  mv ../avairebotapache2.conf .
-  mv commandMap.json storage/commandMap.json
-  mv ../update.sh .
-  mv ../Procfile . # The Procfile will now override the Procfile from the website repo
+if [ -d ".git" ]; then # After compile remove .git (as it will be replaced) and delete everything else with exception after $. Get website except wrong Procfile for this build
+  rm -r .git/ & rm -rf $(find * -name "*" ! -name "AvaIre.jar" ! -name "avairebotapache2.conf" ! -name "Procfile" ! -name "update.sh")
+  git clone https://github.com/avaire/website && rm website/Procfile && mv website/{.[!.],}* . && rm -r website/ # Example: avaire/website
+  java -jar AvaIre.jar & java -jar AvaIre.jar --generate-json-file && mv commandMap.json storage/commandMap.json # Get needed configs and move command file to right directory
 else # If AvaIre.jar isn't compiled
-  echo First part, set the .git folder.
-  git clone https://github.com/avaire/avaire # Example: avaire/avaire
-  mv avaire/.git .
+  git clone https://github.com/avaire/avaire && mv avaire/.git . # Example: avaire/avaire
 fi # The third time the build-run.sh is ran, it won't be this script but the one over at the website repo!

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -20,8 +20,7 @@ if [ -d ".git" ]; then
   rm -r * & rm -r .git/
   # The website is being cloned and moven out of it's folder
   git clone https://github.com/avaire/website # Example: avaire/website
-  mv website/* .
-  mv website/.* .
+  mv website/{.[!.],}* .
   rm -r website/
   # Moving the config files needed to run everything back into the original directory
   mv ../config.yml .

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,7 +1,7 @@
 if [ -d ".git" ]; then # After compile remove .git (as it will be replaced) and delete everything else with exception after $. Get website except wrong Procfile for this build
   rm -r .git/ & rm -rf $(find * -name "*" ! -name "AvaIre.jar" ! -name "avairebotapache2.conf" ! -name "Procfile" ! -name "update.sh")
   git clone https://github.com/avaire/website && rm website/Procfile && mv website/{.[!.],}* . && rm -r website/ # Example: avaire/website
-  java -jar AvaIre.jar & java -jar AvaIre.jar --generate-json-file && mv commandMap.json storage/commandMap.json # Get needed configs and move command file to right directory
+  java -jar AvaIre.jar --generate-json-file && mv commandMap.json storage/commandMap.json # Get needed configs and move command file to right directory
 else # If AvaIre.jar isn't compiled
   git clone https://github.com/avaire/avaire && mv avaire/.git . # Example: avaire/avaire
 fi # The third time the build-run.sh is ran, it won't be this script but the one over at the website repo!

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,41 +1,31 @@
 # If AvaIre.jar is compiled
 if [ -d ".git" ]; then
-  # Second step
-  echo ==========================
-  echo ====== Second Part =======
-  echo ==========================
-  echo Moving some files we want to keep after getting the website. We also generate the commandMap.json.
+  echo Secondly moving some files we want to keep after getting the website. We also generate the commandMap.json.
   echo After getting the website files in the right directory, we move the files back in the right directory with the website files.
   # Generating the commandMap.json
-  java -jar AvaIre.jar --generate-json-file
+  
   # Moving the config files needed to run AvaIre.jar and the Apache2 webserver outside the app/ folder
-  mv src/main/resources/config.yml ../config.yml
-  mv src/main/resources/constants.yml ../constants.yml
   mv AvaIre.jar ../AvaIre.jar
   mv avairebotapache2.conf ../avairebotapache2.conf
-  mv commandMap.json ../commandMap.json
   mv Procfile ../Procfile
   mv update.sh ../update.sh
   # Entire /app/ directory is cleared out, to prepare to retrieve the webfiles
-  rm -r * & rm -r .git/
+  echo doing the big delete tric
+  rm -r -v !("AvaIre.jar"|"avairebotapache2.conf"|"Procfile"|"update.sh") {.[!.],}*
   # The website is being cloned and moven out of it's folder
   git clone https://github.com/avaire/website # Example: avaire/website
   mv website/{.[!.],}* .
   rm -r website/
   # Moving the config files needed to run everything back into the original directory
-  mv ../config.yml .
-  mv ../constants.yml .
   mv ../AvaIre.jar .
+  java -jar AvaIre.jar
+  java -jar AvaIre.jar --generate-json-file
   mv ../avairebotapache2.conf .
   mv ../commandMap.json storage/commandMap.json
   mv ../update.sh .
   mv ../Procfile . # The Procfile will now override the Procfile from the website repo
 # If AvaIre.jar isn't compiled
 else
-  # First step
-  echo ==========================
-  echo ====== First Part ========
-  echo ==========================
   echo First part, set the .git folder.
   git clone https://github.com/avaire/avaire # Example: avaire/avaire
   mv avaire/.git .

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -21,6 +21,7 @@ if [ -d ".git" ]; then
   # The website is being cloned and moven out of it's folder
   git clone https://github.com/avaire/website # Example: avaire/website
   mv website/* .
+  mv website/.* .
   rm -r website/
   # Moving the config files needed to run everything back into the original directory
   mv ../config.yml .

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,18 +1,11 @@
-# If AvaIre.jar is compiled
 if [ -d ".git" ]; then
-  echo Secondly moving some files we want to keep after getting the website. We also generate the commandMap.json.
-  echo After getting the website files in the right directory, we move the files back in the right directory with the website files.
-  # Generating the commandMap.json
-  
-  # Moving the config files needed to run AvaIre.jar and the Apache2 webserver outside the app/ folder
+  echo Second part, move needed files for AvaIre to parent directory. Clean all other files to keep everything organized.
+  echo When website is cloned and moved into the same directory. Needed files are then placed back in current directory.
   mv AvaIre.jar ../AvaIre.jar
   mv avairebotapache2.conf ../avairebotapache2.conf
   mv Procfile ../Procfile
   mv update.sh ../update.sh
-  # Entire /app/ directory is cleared out, to prepare to retrieve the webfiles
-  echo doing the big delete tric
-  rm -r -v !("AvaIre.jar"|"avairebotapache2.conf"|"Procfile"|"update.sh") {.[!.],}*
-  # The website is being cloned and moven out of it's folder
+  rm -r * & rm -r .git # Entire /app/ directory is cleared out, to prepare to retrieve the webfiles
   git clone https://github.com/avaire/website # Example: avaire/website
   mv website/{.[!.],}* .
   rm -r website/
@@ -21,14 +14,11 @@ if [ -d ".git" ]; then
   java -jar AvaIre.jar
   java -jar AvaIre.jar --generate-json-file
   mv ../avairebotapache2.conf .
-  mv ../commandMap.json storage/commandMap.json
+  mv commandMap.json storage/commandMap.json
   mv ../update.sh .
   mv ../Procfile . # The Procfile will now override the Procfile from the website repo
-# If AvaIre.jar isn't compiled
-else
+else # If AvaIre.jar isn't compiled
   echo First part, set the .git folder.
   git clone https://github.com/avaire/avaire # Example: avaire/avaire
   mv avaire/.git .
-fi
-echo This is the end of the script
-# The third time the build-run.sh is ran, it won't be this script but the one over at the website repo!
+fi # The third time the build-run.sh is ran, it won't be this script but the one over at the website repo!


### PR DESCRIPTION
This is the last pull to fix the small issues that have come with moving to the new deploy strategie.

I also found some improvements out, i list them down here, if you confirm it's true that avaire makes the missing .yml files herself.
If your ok to have the update.sh also on the website repo i can remove that command here aswell.

Proposed improvements:
i could run avaire a second time after the commandmap.json, so it makes the following automatically and more scableable:
  
```
 mv src/main/resources/config.yml ../config.yml
 mv src/main/resources/constants.yml ../constants.yml
```

```
  mv ../config.yml .
  mv ../constants.yml .
```

I just need to know for sure, avaire generates the missing yml files if it's ran withoud them?

`mv update.sh ../update.sh`

can maybe be removed if your ok to have this file in the website repo aswell!