### PR TITLE
Create audio database caching for search results

### DIFF
--- a/app.json
+++ b/app.json
@@ -126,6 +126,21 @@
             "required": false,
             "value": "88739639380172800"
         },
+        "AVA_AUDIO_CACHE_MAXIMUM_CACHE_SIZE": {
+            "description": "Defines how large the maximum cache size will be for the in-memory music search results cache.",
+            "required": true,
+            "value": "1000"
+        },
+        "AVA_AUDIO_CACHE_DEFAULT_MAX_CACHE_AGE": {
+            "description": "Defines how old the maximum cache can be before being excluded from search track searches, this value is defined in seconds.",
+            "required": true,
+            "value": "86400"
+        },
+        "AVA_AUDIO_CACHE_MAX_PERSISTENCE_AGE": {
+            "description": "Defines how long a cached search query will be kept in the cache, this value is in seconds.",
+            "required": true,
+            "value": "172800"
+        },
         "AVA_SENTRYDSN": {
             "description": "If you want to use Sentry for error loging. You can get the DSN url from: https://sentry.io/welcome/. You can leave this blank.",
             "required": false,

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'idea'
 
-version = '0.9.152'
+version = '0.9.153'
 group = 'com.avairebot'
 description = 'AvaIre Discord Bot'
 mainClassName = 'com.avairebot.Main'

--- a/src/main/java/com/avairebot/Constants.java
+++ b/src/main/java/com/avairebot/Constants.java
@@ -43,6 +43,8 @@ public class Constants {
     public static final String REACTION_ROLES_TABLE_NAME = "reaction_roles";
     public static final String PURCHASES_TABLE_NAME = "purchases";
     public static final String MUTE_TABLE_NAME = "mutes";
+    public static final String MUSIC_SEARCH_PROVIDERS_TABLE_NAME = "music_search_providers";
+    public static final String MUSIC_SEARCH_CACHE_TABLE_NAME = "music_search_cache";
 
     // Package Specific Information
     public static final String PACKAGE_MIGRATION_PATH = "com.avairebot.database.migrate";

--- a/src/main/java/com/avairebot/audio/TrackRequestContext.java
+++ b/src/main/java/com/avairebot/audio/TrackRequestContext.java
@@ -56,7 +56,8 @@ public class TrackRequestContext {
         if (!provider.isSearchable()) {
             return query;
         }
-        return punctuationRegex.matcher(query).replaceAll("");
+        return punctuationRegex.matcher(query)
+            .replaceAll("");
     }
 
     public String getQuery() {

--- a/src/main/java/com/avairebot/audio/TrackRequestContext.java
+++ b/src/main/java/com/avairebot/audio/TrackRequestContext.java
@@ -57,7 +57,8 @@ public class TrackRequestContext {
             return query;
         }
         return punctuationRegex.matcher(query)
-            .replaceAll("");
+            .replaceAll("")
+            .toLowerCase();
     }
 
     public String getQuery() {

--- a/src/main/java/com/avairebot/audio/cache/AudioTrackSerializer.java
+++ b/src/main/java/com/avairebot/audio/cache/AudioTrackSerializer.java
@@ -30,12 +30,48 @@ import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 @SuppressWarnings("WeakerAccess")
 public class AudioTrackSerializer {
 
     /**
-     * Encodes the given audio track into a byte array which an be
+     * Encodes the given audio tracks in a multi-dimensional byte array
+     * which can be used to re-create the list of the original
+     * audio tracks later on.
+     *
+     * @param tracks The list of LavaPlayer AudioTrack object instances.
+     * @return The encoded byte values of the given audio tracks, or {@code null} if something went wrong.
+     */
+    @Nullable
+    public static byte[][] encodeTracks(List<AudioTrack> tracks) {
+        if (tracks == null || tracks.isEmpty()) {
+            return null;
+        }
+
+        int skipped = 0;
+        byte[][] encoded = new byte[tracks.size()][];
+        for (int i = 0; i < tracks.size(); i++) {
+            encoded[i] = encodeTrack(tracks.get(i));
+            if (encoded[i] == null) {
+                skipped++;
+            }
+        }
+
+        byte[][] result = new byte[tracks.size() - skipped][];
+        int i = 0;
+        for (byte[] encodedTrack : encoded) {
+            if (encodedTrack != null) {
+                result[i++] = encodedTrack;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Encodes the given audio track into a byte array which can be
      * used to re-create the original audio track later.
      *
      * @param audioTrack The LavaPlayer AudioTrack object instance.
@@ -55,6 +91,31 @@ public class AudioTrackSerializer {
         } catch (IOException ignored) {
             return null;
         }
+    }
+
+    /**
+     * Decodes the given multi-dimensional byte array into a list of LavaPlayer
+     * AudioTrack instances, creating the original audio track objects.
+     *
+     * @param input The byte arrays which should be decoded into the AudioTrack instances.
+     * @return The decoded LavaPlayer AudioTrack object instances, or {@code null} if
+     *         the given by arrays does not match a audio track.
+     */
+    @Nullable
+    public static List<AudioTrack> decodeTracks(byte[][] input) {
+        if (input == null) {
+            return null;
+        }
+
+        List<AudioTrack> audioTracks = new ArrayList<>();
+        for (byte[] trackArray : input) {
+            AudioTrack track = decodeTrack(trackArray);
+            if (track != null) {
+                audioTracks.add(track);
+            }
+        }
+
+        return audioTracks;
     }
 
     /**

--- a/src/main/java/com/avairebot/audio/seracher/SearchProvider.java
+++ b/src/main/java/com/avairebot/audio/seracher/SearchProvider.java
@@ -24,6 +24,7 @@ package com.avairebot.audio.seracher;
 import com.avairebot.contracts.toggle.Feature;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public enum SearchProvider implements Feature {
@@ -49,7 +50,17 @@ public enum SearchProvider implements Feature {
         this.domains = domains;
     }
 
-    public static SearchProvider fromTrack(AudioTrack track) {
+    /**
+     * Gets the search provider matching the source of the given audio track,
+     * if no search providers matches were found the {@link #URL url search
+     * provider} will be returned instead.
+     *
+     * @param track The audio track the search provider should be loaded for.
+     * @return The matching search provider for the given audio track,
+     *         or the {@link #URL url search provider}.
+     */
+    @Nonnull
+    public static SearchProvider fromTrack(@Nonnull AudioTrack track) {
         String trackUrl = track.getInfo().uri;
         for (SearchProvider provider : values()) {
             if (provider.getDomains() != null && provider.matchesDomain(trackUrl)) {
@@ -59,6 +70,13 @@ public enum SearchProvider implements Feature {
         return DEFAULT_PROVIDER;
     }
 
+    /**
+     * Gets the matching search provider by name.
+     *
+     * @param name The name of the search provider that should be returned.
+     * @return The matching search provider for the given name,
+     *         or {@code NULL} if there were no match.
+     */
     @Nullable
     public static SearchProvider fromName(String name) {
         for (SearchProvider provider : values()) {
@@ -69,6 +87,14 @@ public enum SearchProvider implements Feature {
         return null;
     }
 
+    /**
+     * Gets the matching search provider by its ID.
+     *
+     * @param id The ID of the search provider that should be returned.
+     * @return The matching search provider for the given ID,
+     *         or {@code NULL} if there were no match.
+     */
+    @Nullable
     public static SearchProvider fromId(int id) {
         for (SearchProvider provider : values()) {
             if (provider.getId() == id) {
@@ -78,18 +104,50 @@ public enum SearchProvider implements Feature {
         return null;
     }
 
+    /**
+     * The unique ID of the search provider, the ID is used to represent cached
+     * search results stored in the database, along with the query used
+     * to fetch the original search result in the first place.
+     *
+     * @return The ID of the search provider.
+     */
     public int getId() {
         return id;
     }
 
+    /**
+     * The searchable prefix used by LavaPlayer to search
+     * for tracks using the current provider.
+     *
+     * @return The prefix used for search in LavaPlayer, or {@code NULL} if
+     *         the current instance is not a searchable search provider.
+     */
+    @Nullable
     public String getPrefix() {
         return prefix;
     }
 
+    /**
+     * The array of domains that is used by the current search provider,
+     * if the search provider doesn't have any domains liked to it,
+     * it will just return an empty string array instead.
+     *
+     * @return The array of domains used by the search providers.
+     */
     public String[] getDomains() {
         return domains;
     }
 
+    /**
+     * Checks if the given string matches any of the domains for the current
+     * search provider, the string is matched to make sure it just contains
+     * the words for the domain in the string, not that the entire string
+     * matches one of the domains.
+     *
+     * @param string The string that should be matched against the domains.
+     * @return {@code True} if the given string contains one of the domains
+     *         for the current provider, {@code False} otherwise.
+     */
     public boolean matchesDomain(String string) {
         if (string == null) {
             return false;
@@ -104,6 +162,12 @@ public enum SearchProvider implements Feature {
         return false;
     }
 
+    /**
+     * Checks if the current search provider is searchable or not.
+     *
+     * @return {@code True} if the search provider is searchable,
+     *         {@code False} otherwise.
+     */
     public boolean isSearchable() {
         return getPrefix() != null
             && getDomains() != null;

--- a/src/main/java/com/avairebot/audio/seracher/SearchProvider.java
+++ b/src/main/java/com/avairebot/audio/seracher/SearchProvider.java
@@ -69,6 +69,15 @@ public enum SearchProvider implements Feature {
         return null;
     }
 
+    public static SearchProvider fromId(int id) {
+        for (SearchProvider provider : values()) {
+            if (provider.getId() == id) {
+                return provider;
+            }
+        }
+        return null;
+    }
+
     public int getId() {
         return id;
     }

--- a/src/main/java/com/avairebot/audio/seracher/SearchProvider.java
+++ b/src/main/java/com/avairebot/audio/seracher/SearchProvider.java
@@ -28,21 +28,23 @@ import javax.annotation.Nullable;
 
 public enum SearchProvider implements Feature {
 
-    YOUTUBE("ytsearch:", "youtube.com", "youtu.be"),
-    SOUNDCLOUD("scsearch:", "soundcloud.com"),
-    LOCAL,
-    URL;
+    YOUTUBE(1, "ytsearch:", "youtube.com", "youtu.be"),
+    SOUNDCLOUD(2, "scsearch:", "soundcloud.com"),
+    LOCAL(3),
+    URL(4);
 
     private static final SearchProvider DEFAULT_PROVIDER = URL;
 
+    private final int id;
     private final String prefix;
     private final String[] domains;
 
-    SearchProvider() {
-        this(null);
+    SearchProvider(int id) {
+        this(id, null);
     }
 
-    SearchProvider(String prefix, String... domains) {
+    SearchProvider(int id, String prefix, String... domains) {
+        this.id = id;
         this.prefix = prefix;
         this.domains = domains;
     }
@@ -65,6 +67,10 @@ public enum SearchProvider implements Feature {
             }
         }
         return null;
+    }
+
+    public int getId() {
+        return id;
     }
 
     public String getPrefix() {

--- a/src/main/java/com/avairebot/audio/seracher/SearchTrackResultHandler.java
+++ b/src/main/java/com/avairebot/audio/seracher/SearchTrackResultHandler.java
@@ -38,6 +38,7 @@ import com.sedmelluq.discord.lavaplayer.track.BasicAudioPlaylist;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
@@ -55,14 +56,54 @@ public class SearchTrackResultHandler implements AudioLoadResultHandler {
     private Exception exception;
     private AudioPlaylist playlist;
 
+    /**
+     * Creates a new search track result handler for the given track context.
+     *
+     * @param trackContext The track request context that should be used for the search.
+     */
     public SearchTrackResultHandler(TrackRequestContext trackContext) {
         this.trackContext = trackContext;
     }
 
+    /**
+     * Search for an audio playlist using the set track request context,
+     * with a 3000 millisecond timeout in the current thread.
+     * <p>
+     * The search will automatically use the audio cache unless specified otherwise,
+     * and only use search providers that are globally enabled.
+     *
+     * @return The playlist returned from the search request, if no result were found but no
+     *         exception were thrown, an empty audio playlist will be returned instead,
+     *         with no selected track, and an empty track list.
+     * @throws SearchingException If an invalid search request is made, or something goes wrong while
+     *                            searching for audio playlists using the given request context.
+     *                            Things like searching for direct links for a search provider
+     *                            that is disabled, or an exception is thrown while making
+     *                            the search, causing the search to fail.
+     */
+    @Nonnull
     public AudioPlaylist searchSync() throws SearchingException {
         return searchSync(defaultTimeout);
     }
 
+    /**
+     * Search for an audio playlist using the set track request context in the current thread.
+     * <p>
+     * The search will automatically use the audio cache unless specified otherwise,
+     * and only use search providers that are globally enabled.
+     *
+     * @param timeoutMillis The amount of time to wait before the search request times
+     *                      out in milliseconds.
+     * @return The playlist returned from the search request, if no result were found but no
+     *         exception were thrown, an empty audio playlist will be returned instead,
+     *         with no selected track, and an empty track list.
+     * @throws SearchingException If an invalid search request is made, or something goes wrong while
+     *                            searching for audio playlists using the given request context.
+     *                            Things like searching for direct links for a search provider
+     *                            that is disabled, or an exception is thrown while making
+     *                            the search, causing the search to fail.
+     */
+    @Nonnull
     public AudioPlaylist searchSync(long timeoutMillis) throws SearchingException {
         Metrics.searchRequests.inc();
 
@@ -132,6 +173,12 @@ public class SearchTrackResultHandler implements AudioLoadResultHandler {
         return playlist;
     }
 
+    /**
+     * Sets whether the cache should be used in the request or not.
+     *
+     * @param skipCache The value that should determine if the cache is used or not.
+     * @return An instance of the current search result handler.
+     */
     public SearchTrackResultHandler skipCache(boolean skipCache) {
         this.skipCache = skipCache;
 

--- a/src/main/java/com/avairebot/database/DatabaseManager.java
+++ b/src/main/java/com/avairebot/database/DatabaseManager.java
@@ -426,6 +426,10 @@ public class DatabaseManager {
     }
 
     private void runQueryBatch(String query, BatchQueryFunction<PreparedStatement> queryFunction, int batchId, int retriesLeft) throws SQLException {
+        log.debug("Running batch query with the following values:\n - Query: {}\n - Batch ID: {}\n - Retries Left: {}",
+            query, batchId, retriesLeft
+        );
+
         Connection connection = getConnection().getConnection();
 
         if (!runningBatchRequests.contains(batchId)) {

--- a/src/main/java/com/avairebot/database/controllers/SearchController.java
+++ b/src/main/java/com/avairebot/database/controllers/SearchController.java
@@ -67,10 +67,8 @@ public class SearchController {
         }
 
         try {
-            String searchQueryFromContext = createSearchQueryFromContext(context, maxCacheAgeInMilis);
-            log.debug("Query: {}", searchQueryFromContext);
             Collection result = AvaIre.getInstance().getDatabase().query(
-                searchQueryFromContext
+                createSearchQueryFromContext(context, maxCacheAgeInMilis)
             );
 
             if (result.isEmpty()) {

--- a/src/main/java/com/avairebot/database/controllers/SearchController.java
+++ b/src/main/java/com/avairebot/database/controllers/SearchController.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.database.controllers;
+
+import com.avairebot.AvaIre;
+import com.avairebot.Constants;
+import com.avairebot.audio.TrackRequestContext;
+import com.avairebot.database.collection.Collection;
+import com.avairebot.database.transformers.PurchasesTransformer;
+import com.avairebot.database.transformers.SearchResultTransformer;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
+
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+
+public class SearchController {
+
+    public static final Cache<Long, PurchasesTransformer> cache = CacheBuilder.newBuilder()
+        .recordStats()
+        .expireAfterAccess(30, TimeUnit.MINUTES)
+        .build();
+
+    public static SearchResultTransformer fetchSearchResult(TrackRequestContext context) {
+        try {
+            Collection result = AvaIre.getInstance().getDatabase().newQueryBuilder(Constants.MUSIC_SEARCH_CACHE_TABLE_NAME)
+                .where("provider", context.getProvider().getId())
+                .where("query", context.getProvider().isSearchable()
+                    ? context.getQuery().toLowerCase().trim()
+                    : context.getQuery()
+                ).get();
+
+            if (result.isEmpty()) {
+                return null;
+            }
+
+            return new SearchResultTransformer(result.first());
+        } catch (SQLException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public static void cacheSearchResult(TrackRequestContext context, AudioPlaylist playlist) {
+        try {
+            AvaIre.getInstance().getDatabase().newQueryBuilder(Constants.MUSIC_SEARCH_CACHE_TABLE_NAME)
+                .useAsync(true)
+                .insert(statement -> {
+                    statement.set("provider", context.getProvider().getId());
+                    statement.set("query", context.getProvider().isSearchable()
+                        ? context.getQuery().toLowerCase().trim()
+                        : context.getQuery()
+                    );
+                    statement.set("result", new SearchResultTransformer.SerializableAudioPlaylist(playlist).toString(), true);
+                });
+        } catch (SQLException e) {
+            // This will never be thrown since we're using an Async query.
+        }
+    }
+}

--- a/src/main/java/com/avairebot/database/migrate/migrations/CreateMusicSearchCacheTableMigration.java
+++ b/src/main/java/com/avairebot/database/migrate/migrations/CreateMusicSearchCacheTableMigration.java
@@ -23,6 +23,7 @@ package com.avairebot.database.migrate.migrations;
 
 import com.avairebot.Constants;
 import com.avairebot.contracts.database.migrations.Migration;
+import com.avairebot.database.schema.DefaultSQLAction;
 import com.avairebot.database.schema.Schema;
 
 import java.sql.SQLException;
@@ -40,7 +41,7 @@ public class CreateMusicSearchCacheTableMigration implements Migration {
             table.Integer("provider");
             table.String("query");
             table.LongText("result").nullable();
-            table.Timestamps();
+            table.DateTime("created_at").defaultValue(new DefaultSQLAction("CURRENT_TIMESTAMP"));
         });
     }
 

--- a/src/main/java/com/avairebot/database/migrate/migrations/CreateMusicSearchCacheTableMigration.java
+++ b/src/main/java/com/avairebot/database/migrate/migrations/CreateMusicSearchCacheTableMigration.java
@@ -41,6 +41,7 @@ public class CreateMusicSearchCacheTableMigration implements Migration {
             table.Integer("provider");
             table.String("query");
             table.LongText("result").nullable();
+            table.DateTime("last_lookup_at").defaultValue(new DefaultSQLAction("CURRENT_TIMESTAMP"));
             table.DateTime("created_at").defaultValue(new DefaultSQLAction("CURRENT_TIMESTAMP"));
         });
     }

--- a/src/main/java/com/avairebot/database/migrate/migrations/CreateMusicSearchCacheTableMigration.java
+++ b/src/main/java/com/avairebot/database/migrate/migrations/CreateMusicSearchCacheTableMigration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.database.migrate.migrations;
+
+import com.avairebot.Constants;
+import com.avairebot.contracts.database.migrations.Migration;
+import com.avairebot.database.schema.Schema;
+
+import java.sql.SQLException;
+
+public class CreateMusicSearchCacheTableMigration implements Migration {
+
+    @Override
+    public String created_at() {
+        return "Sun, Oct 13, 2019 3:45 PM";
+    }
+
+    @Override
+    public boolean up(Schema schema) throws SQLException {
+        return schema.createIfNotExists(Constants.MUSIC_SEARCH_CACHE_TABLE_NAME, table -> {
+            table.Integer("provider");
+            table.String("query");
+            table.LongText("result").nullable();
+            table.Timestamps();
+        });
+    }
+
+    @Override
+    public boolean down(Schema schema) throws SQLException {
+        return schema.dropIfExists(Constants.MUSIC_SEARCH_CACHE_TABLE_NAME);
+    }
+}

--- a/src/main/java/com/avairebot/database/migrate/migrations/CreateMusicSearchProvidersTableMigration.java
+++ b/src/main/java/com/avairebot/database/migrate/migrations/CreateMusicSearchProvidersTableMigration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.database.migrate.migrations;
+
+import com.avairebot.Constants;
+import com.avairebot.contracts.database.migrations.Migration;
+import com.avairebot.database.schema.Schema;
+
+import java.sql.SQLException;
+
+public class CreateMusicSearchProvidersTableMigration implements Migration {
+
+    @Override
+    public String created_at() {
+        return "Sun, Oct 13, 2019 3:39 PM";
+    }
+
+    @Override
+    public boolean up(Schema schema) throws SQLException {
+        return schema.createIfNotExists(Constants.MUSIC_SEARCH_PROVIDERS_TABLE_NAME, table -> {
+            table.Integer("id");
+            table.String("name");
+        });
+    }
+
+    @Override
+    public boolean down(Schema schema) throws SQLException {
+        return schema.dropIfExists(Constants.MUSIC_SEARCH_PROVIDERS_TABLE_NAME);
+    }
+}

--- a/src/main/java/com/avairebot/database/query/QueryBuilder.java
+++ b/src/main/java/com/avairebot/database/query/QueryBuilder.java
@@ -728,6 +728,17 @@ public final class QueryBuilder {
      *         or (2) <code>NULL</code> if an error occurred.
      */
     public String toSQL() {
+        return toSQL(type);
+    }
+
+    /**
+     * Creates the grammar instance and builds the SQL query using the given query type, if an
+     * error occurs while building the query <code>NULL</code> will be returned instead.
+     *
+     * @return either (1) the generated SQL query
+     *         or (2) <code>NULL</code> if an error occurred.
+     */
+    public String toSQL(QueryType type) {
         try {
             switch (type) {
                 case SELECT:

--- a/src/main/java/com/avairebot/database/schema/Schema.java
+++ b/src/main/java/com/avairebot/database/schema/Schema.java
@@ -255,7 +255,9 @@ public class Schema {
      *                      <code>ResultSet</code> object, the method is called on a
      *                      <code>PreparedStatement</code> or <code>CallableStatement</code>
      */
-    private boolean alterQuery(String query) throws SQLException {
+    public boolean alterQuery(String query) throws SQLException {
+        log.debug("alertQuery(String query) was called with the following SQL query.\nSQL: " + query);
+
         Statement stmt = dbm.getConnection().getConnection().createStatement();
 
         return !stmt.execute(query);

--- a/src/main/java/com/avairebot/database/seeder/seeders/MusicSearchProviderTableSeeder.java
+++ b/src/main/java/com/avairebot/database/seeder/seeders/MusicSearchProviderTableSeeder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.database.seeder.seeders;
+
+import com.avairebot.AvaIre;
+import com.avairebot.Constants;
+import com.avairebot.audio.seracher.SearchProvider;
+import com.avairebot.contracts.database.seeder.Seeder;
+
+import java.sql.SQLException;
+
+public class MusicSearchProviderTableSeeder extends Seeder {
+
+    public MusicSearchProviderTableSeeder(AvaIre avaire) {
+        super(avaire);
+    }
+
+    @Override
+    public String table() {
+        return Constants.MUSIC_SEARCH_PROVIDERS_TABLE_NAME;
+    }
+
+    @Override
+    public void run() throws SQLException {
+        for (SearchProvider provider : SearchProvider.values()) {
+            createQuery().insert(statement -> {
+                statement.set("id", provider.getId());
+                statement.set("name", provider);
+            });
+        }
+    }
+}

--- a/src/main/java/com/avairebot/database/seeder/seeders/MusicSearchProviderTableSeeder.java
+++ b/src/main/java/com/avairebot/database/seeder/seeders/MusicSearchProviderTableSeeder.java
@@ -42,10 +42,12 @@ public class MusicSearchProviderTableSeeder extends Seeder {
     @Override
     public void run() throws SQLException {
         for (SearchProvider provider : SearchProvider.values()) {
-            createQuery().insert(statement -> {
-                statement.set("id", provider.getId());
-                statement.set("name", provider);
-            });
+            if (!tableHasValue("id", provider.getId())) {
+                createQuery().insert(statement -> {
+                    statement.set("id", provider.getId());
+                    statement.set("name", provider);
+                });
+            }
         }
     }
 }

--- a/src/main/java/com/avairebot/database/transformers/SearchResultTransformer.java
+++ b/src/main/java/com/avairebot/database/transformers/SearchResultTransformer.java
@@ -41,7 +41,7 @@ public class SearchResultTransformer extends Transformer {
         super(data);
 
         if (hasData()) {
-            provider = SearchProvider.fromName(data.getString("provider"));
+            provider = SearchProvider.fromId(data.getInt("provider", -1));
             query = data.getString("query");
             serializableAudioPlaylist = AvaIre.gson.fromJson(
                 data.getString("result"), new TypeToken<SerializableAudioPlaylist>() {

--- a/src/main/java/com/avairebot/database/transformers/SearchResultTransformer.java
+++ b/src/main/java/com/avairebot/database/transformers/SearchResultTransformer.java
@@ -38,6 +38,12 @@ public class SearchResultTransformer extends Transformer {
     private String query;
     private SerializableAudioPlaylist serializableAudioPlaylist;
 
+    /**
+     * Creates a new search result transformer for
+     * the given data row result.
+     *
+     * @param data The data row returned from a database query.
+     */
     public SearchResultTransformer(DataRow data) {
         super(data);
 
@@ -55,6 +61,15 @@ public class SearchResultTransformer extends Transformer {
         }
     }
 
+    /**
+     * Creates a new search result transformer for the given
+     * track request context and audio playlist.
+     *
+     * @param context  The track request context that should be used
+     *                 in the search result transformer.
+     * @param playlist The Audio Playlist that should be used in
+     *                 the search result transformer.
+     */
     public SearchResultTransformer(TrackRequestContext context, AudioPlaylist playlist) {
         super(null);
 
@@ -63,18 +78,42 @@ public class SearchResultTransformer extends Transformer {
         this.serializableAudioPlaylist = new SerializableAudioPlaylist(playlist);
     }
 
+    /**
+     * Gets the search provider used as a cache key for the search result.
+     *
+     * @return The search provider used as a cache key for the search result.
+     */
     public SearchProvider getProvider() {
         return provider;
     }
 
+    /**
+     * Gets the search query used as a cache key for the search result.
+     *
+     * @return The search query used as a cache key for the search result.
+     */
     public String getQuery() {
         return query;
     }
 
+    /**
+     * Gets the serializable audio playlist instance, this will contain all
+     * the audio tracks contained in the result as a byte array,
+     * as-well-as some information about the playlist like
+     * it's name and search status.
+     *
+     * @return The serializable audio playlist instance.
+     */
     public SerializableAudioPlaylist getSerializableAudioPlaylist() {
         return serializableAudioPlaylist;
     }
 
+    /**
+     * Gets the audio playlist instance, this will create a completely new audio playlist
+     * instance from the {@link #getSerializableAudioPlaylist() serialized playlist}.
+     *
+     * @return The audio playlist instance stored in the cache.
+     */
     public AudioPlaylist getAudioPlaylist() {
         return new BasicAudioPlaylist(
             serializableAudioPlaylist.name,

--- a/src/main/java/com/avairebot/database/transformers/SearchResultTransformer.java
+++ b/src/main/java/com/avairebot/database/transformers/SearchResultTransformer.java
@@ -22,6 +22,7 @@
 package com.avairebot.database.transformers;
 
 import com.avairebot.AvaIre;
+import com.avairebot.audio.TrackRequestContext;
 import com.avairebot.audio.cache.AudioTrackSerializer;
 import com.avairebot.audio.seracher.SearchProvider;
 import com.avairebot.contracts.database.transformers.Transformer;
@@ -52,6 +53,14 @@ public class SearchResultTransformer extends Transformer {
                 throw new InvalidStateException("The serializable audio playlist is null, this should not happen for cached results");
             }
         }
+    }
+
+    public SearchResultTransformer(TrackRequestContext context, AudioPlaylist playlist) {
+        super(null);
+
+        this.provider = context.getProvider();
+        this.query = context.getQuery();
+        this.serializableAudioPlaylist = new SerializableAudioPlaylist(playlist);
     }
 
     public SearchProvider getProvider() {

--- a/src/main/java/com/avairebot/database/transformers/SearchResultTransformer.java
+++ b/src/main/java/com/avairebot/database/transformers/SearchResultTransformer.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.database.transformers;
+
+import com.avairebot.AvaIre;
+import com.avairebot.audio.cache.AudioTrackSerializer;
+import com.avairebot.audio.seracher.SearchProvider;
+import com.avairebot.contracts.database.transformers.Transformer;
+import com.avairebot.database.collection.DataRow;
+import com.google.gson.reflect.TypeToken;
+import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
+import com.sedmelluq.discord.lavaplayer.track.BasicAudioPlaylist;
+import sun.plugin.dom.exception.InvalidStateException;
+
+public class SearchResultTransformer extends Transformer {
+
+    private SearchProvider provider;
+    private String query;
+    private SerializableAudioPlaylist serializableAudioPlaylist;
+
+    public SearchResultTransformer(DataRow data) {
+        super(data);
+
+        if (hasData()) {
+            provider = SearchProvider.fromName(data.getString("provider"));
+            query = data.getString("query");
+            serializableAudioPlaylist = AvaIre.gson.fromJson(
+                data.getString("result"), new TypeToken<SerializableAudioPlaylist>() {
+                }.getType()
+            );
+
+            if (serializableAudioPlaylist == null) {
+                throw new InvalidStateException("The serializable audio playlist is null, this should not happen for cached results");
+            }
+        }
+    }
+
+    public SearchProvider getProvider() {
+        return provider;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public SerializableAudioPlaylist getSerializableAudioPlaylist() {
+        return serializableAudioPlaylist;
+    }
+
+    public AudioPlaylist getAudioPlaylist() {
+        return new BasicAudioPlaylist(
+            serializableAudioPlaylist.name,
+            AudioTrackSerializer.decodeTracks(serializableAudioPlaylist.tracks),
+            AudioTrackSerializer.decodeTrack(serializableAudioPlaylist.selectedTrack),
+            serializableAudioPlaylist.isSearchResult
+        );
+    }
+
+    public static class SerializableAudioPlaylist {
+
+        private String name;
+        private boolean isSearchResult;
+        private byte[] selectedTrack;
+        private byte[][] tracks;
+
+        public SerializableAudioPlaylist(AudioPlaylist playlist) {
+            this.name = playlist.getName();
+            this.isSearchResult = playlist.isSearchResult();
+            this.selectedTrack = AudioTrackSerializer.encodeTrack(playlist.getSelectedTrack());
+            this.tracks = AudioTrackSerializer.encodeTracks(playlist.getTracks());
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public byte[] getSelectedTrack() {
+            return selectedTrack;
+        }
+
+        public byte[][] getTracks() {
+            return tracks;
+        }
+
+        public boolean isSearchResult() {
+            return isSearchResult;
+        }
+
+        @Override
+        public String toString() {
+            return AvaIre.gson.toJson(this);
+        }
+    }
+}

--- a/src/main/java/com/avairebot/metrics/Metrics.java
+++ b/src/main/java/com/avairebot/metrics/Metrics.java
@@ -113,9 +113,15 @@ public class Metrics {
 
     // Music
 
-    public static final Counter searchRequests = Counter.build() //search requests issued by users
+    public static final Counter searchRequests = Counter.build() // Search requests issued by users
         .name("avaire_music_search_requests_total")
         .help("Total search requests")
+        .register();
+
+    public static final Counter searchHits = Counter.build()
+        .name("avaire_music_search_hits")
+        .help("Total search hits")
+        .labelNames("type")
         .register();
 
     public static final Counter tracksLoaded = Counter.build()

--- a/src/main/java/com/avairebot/metrics/Metrics.java
+++ b/src/main/java/com/avairebot/metrics/Metrics.java
@@ -263,6 +263,7 @@ public class Metrics {
         cacheMetrics.addCache("interaction-lottery", InteractionCommand.cache);
         cacheMetrics.addCache("blacklist-ratelimit", Ratelimit.cache);
         cacheMetrics.addCache("lavalink-destroy-cleanup", LavalinkGarbageNodeCollectorJob.cache);
+        cacheMetrics.addCache("music-search-results", SearchController.cache);
 
         if (!avaire.getConfig().getBoolean("web-servlet.metrics",
             avaire.getConfig().getBoolean("metrics.enabled", true)

--- a/src/main/java/com/avairebot/scheduler/jobs/DeleteExpiredMusicCacheEntitiesJob.java
+++ b/src/main/java/com/avairebot/scheduler/jobs/DeleteExpiredMusicCacheEntitiesJob.java
@@ -41,9 +41,14 @@ public class DeleteExpiredMusicCacheEntitiesJob extends Job {
 
     @Override
     public void run() {
+        final Carbon time = Carbon.now().subSeconds(Math.max(
+            Math.max(avaire.getConfig().getInt("audio-cache.default-max-cache-age", 86400), 60),
+            avaire.getConfig().getInt("audio-cache.max-persistence-age", 172800)
+        ));
+
         try {
             AvaIre.getInstance().getDatabase().newQueryBuilder(Constants.MUSIC_SEARCH_CACHE_TABLE_NAME)
-                .where("created_at", "<", Carbon.now().subDays(2))
+                .where("created_at", "<", time)
                 .delete();
         } catch (SQLException e) {
             log.error("Failed to clear old database records, message: {}", e.getMessage(), e);

--- a/src/main/java/com/avairebot/scheduler/jobs/DeleteExpiredMusicCacheEntitiesJob.java
+++ b/src/main/java/com/avairebot/scheduler/jobs/DeleteExpiredMusicCacheEntitiesJob.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.scheduler.jobs;
+
+import com.avairebot.AvaIre;
+import com.avairebot.Constants;
+import com.avairebot.contracts.scheduler.Job;
+import com.avairebot.time.Carbon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+
+public class DeleteExpiredMusicCacheEntitiesJob extends Job {
+
+    private static final Logger log = LoggerFactory.getLogger(DeleteExpiredMusicCacheEntitiesJob.class);
+
+    public DeleteExpiredMusicCacheEntitiesJob(AvaIre avaire) {
+        super(avaire, 5, 15, TimeUnit.MINUTES);
+    }
+
+    @Override
+    public void run() {
+        try {
+            AvaIre.getInstance().getDatabase().newQueryBuilder(Constants.MUSIC_SEARCH_CACHE_TABLE_NAME)
+                .where("created_at", "<", Carbon.now().subDays(2))
+                .delete();
+        } catch (SQLException e) {
+            log.error("Failed to clear old database records, message: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -338,6 +338,71 @@ audio-quality:
     encoding: 10
 
 #--------------------------------------------------------------------------
+# Audio Cache and Storage
+#--------------------------------------------------------------------------
+#
+# Audio caching and storage is used by Ava when requesting music from
+# different providers(YouTube, Soundcloud, etc), allowing the bot
+# save and re-use responses for different queries.
+#
+# The system allows the bot is able to serve users faster if the same song
+# is requested twice, as-well as lowing the number of times needed to
+# send requests to YouTube, Soundcloud, Twitch, etc.
+#
+
+audio-cache:
+
+    # The maximum cache size value is used to determine the maximum amount of
+    # audio playlists that is allowed to be stored in the memory cache for
+    # audio requests.
+    #
+    # The higher the value the more tracks is able to be stored in the cache,
+    # however more tracks stored in-memory also means the bot will require
+    # more RAM to store all the information.
+    #
+    # Note: The in-memory cache will only store data for 30 minutes at a time
+    # unless it's requested a lot, in which case the cached time is reset
+    # until it's not requested anymore.
+    #
+    # The cache isn't necessarily full at any time either, so even if the max
+    # cache size is high, it doesn't mean every slot in the cache is always
+    # used if there isn't enough requested tracks to store in the cache.
+    #
+    maximum-cache-size: 1000
+
+    # The default max cache age is used when querying for search results and
+    # no specific cache age scope is set for the request, some audio cache
+    # lookups may specify their own max cache age, however if non is
+    # defined, the default max cache age will be used instead.
+    #
+    # The cache age is used with looking for search results in the database
+    # cache, if entries are found matching our query but the entries are
+    # older than the max age, it will be excluded from the results.
+    #
+    # The default max cache age is set in seconds, by default it is set to 86,400
+    # which is 24 hours, the number can be raised to increase the lookup range,
+    # or lower it to narrow the search range down, however the number has to
+    # be more than 60 seconds, so the cache is at most 1 minute old.
+    #
+    default-max-cache-age: 86400
+
+    # The max persistence age is the maximum amount of time an audio search result
+    # is allowed to be stored in the database cache before it is counted as
+    # invalid, and is deleted completely from the database.
+    #
+    # Once a track is deleted from the database cache it will no-longer exist in
+    # any cache and will have to be re-requested via a lookup with
+    # the "!play" command to be re-stored in the database.
+    #
+    # The max persistence age is set in seconds, by default it is set to 172,800
+    # which is 48 hours, the number can be raised to store tracks for a longer
+    # period of time, or lowered in order to not store tracks for long
+    # periods of time, however the number has to be greater than
+    # the default max age set above.
+    #
+    max-persistence-age: 172800
+
+#--------------------------------------------------------------------------
 # Bot Access (Bot Administrators)
 #--------------------------------------------------------------------------
 #


### PR DESCRIPTION
This PR adds caching for audio tracks requested from any source, and stores them in the database, this change should help lower the outgoing requests to services like YouTube and SoundCloud, overall making it a better experience since the bot should (hopefully) not get rate limited anymore.

**TODO List:**
- [x] Make sure the cache lookup queries in the database can't be used as SQL injections.
- [x] Add the Guava cache layer in between the database cache and the search handler to speed up load times for cached items.
	- Look into setting a max cache size for the Guava cache, optionally use a LFU cache instead to help prevent storing a crazy amount of things in-memory.
- [x] Add support for querying for cached items by their age.
	- This should make it possible to specify how long we want our cache to be before it's counted as invalid.
- [x] Add a new metric counter which tracks the different search hits.
	- The metric should track search hits, cache hits, in-memory cache hits, etc, this will allow the bot to give a better idea of how effective the audio cache actually is.
- [x] Create a job to clear out old/expired cached records in the database.
	- Look into if the search results for services like YouTube still works after being cached for multiple days first, since some search results for some services returns custom unique source URLs for requested resources, they might expire or only exist for some set amount of time, if that is the case, clearing out the database of records exceeding that time limit would be a good idea, however even if that's not the case, it's still a good idea to delete records that haven't been requested in a while to prevent the cache table being overflowed with old, unaccessed records, a system just need to be put in place to track when a resource was last loaded from the database cache.
- [x] Add support for configuring things like the max cache size for in-memory audio tracks, default cache age/time, and other relevant things, via the config.yml file. 
- [x] Add documentation to new public API methods.