### PR TITLE
Add support for MariaDB when using Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,9 +19,12 @@
     "repository": "https://github.com/avaire/avaire",
     "logo": "https://imgur.com/H8RCD5F.png",
     "success_url": "/",
+    "scripts": {
+      "postdeploy": "java -jar AvaIre.jar & sleep 30s && exit 0"
+    },
     "addons": [
         {
-            "plan": "jawsdb:kitefin"
+            "plan": "jawsdb-maria:kitefin"
         },
         {
             "plan": "scheduler:standard"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'idea'
 
-version = '0.9.162'
+version = '0.9.163'
 group = 'com.avairebot'
 description = 'AvaIre Discord Bot'
 mainClassName = 'com.avairebot.Main'

--- a/src/main/java/com/avairebot/config/EnvironmentMacros.java
+++ b/src/main/java/com/avairebot/config/EnvironmentMacros.java
@@ -24,6 +24,7 @@ package com.avairebot.config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -40,8 +41,10 @@ public class EnvironmentMacros {
      * Registers the default environment override macros.
      */
     public static void registerDefaults() {
-        if (!registerJAWSDB_MARIA_URL()) {
-            log.warn("Failed to register the JAWSDB_URL environment variable macro, a macro with that name is already registered.");
+        for (String envString : Arrays.asList("JAWSDB_URL", "JAWSDB_MARIA_URL")) {
+            if (!registerJAWSDBString(envString)) {
+                log.warn("Failed to register the {} environment variable macro, a macro with that name is already registered.", envString);
+            }
         }
 
         if (!registerServletPort()) {
@@ -55,21 +58,21 @@ public class EnvironmentMacros {
         });
     }
 
-    private static boolean registerJAWSDB_MARIA_URL() {
-        return EnvironmentOverride.registerMacro("JAWSDB_MARIA_URL", (environmentValue, configuration) -> {
+    private static boolean registerJAWSDBString(String name) {
+        return EnvironmentOverride.registerMacro(name, (environmentValue, configuration) -> {
             if (!configuration.isSet("database.type")) {
                 return;
             }
 
             Matcher matcher = jawsDBUrlPattern.matcher(environmentValue);
             if (!matcher.matches()) {
-                log.debug("Invalid JAWSDB URL environment variable was found, ignoring variable");
-                log.debug("JAWSDB URL environment value: " + environmentValue);
+                log.debug("Invalid {} URL environment variable was found, ignoring variable", name);
+                log.debug("{} environment value: {}", name, environmentValue);
                 return;
             }
 
-            log.debug("Valid JAWSDB URL environment variable was found, storing the variable to the config");
-            log.debug("JAWSDB URL environment value: " + environmentValue);
+            log.debug("Valid {} URL environment variable was found, storing the variable to the config", name);
+            log.debug("{} URL environment value: {}", name, environmentValue);
 
             MatchResult result = matcher.toMatchResult();
 

--- a/src/main/java/com/avairebot/config/EnvironmentMacros.java
+++ b/src/main/java/com/avairebot/config/EnvironmentMacros.java
@@ -40,7 +40,7 @@ public class EnvironmentMacros {
      * Registers the default environment override macros.
      */
     public static void registerDefaults() {
-        if (!registerJAWSDB_URL()) {
+        if (!registerJAWSDB_MARIA_URL()) {
             log.warn("Failed to register the JAWSDB_URL environment variable macro, a macro with that name is already registered.");
         }
 
@@ -55,8 +55,8 @@ public class EnvironmentMacros {
         });
     }
 
-    private static boolean registerJAWSDB_URL() {
-        return EnvironmentOverride.registerMacro("JAWSDB_URL", (environmentValue, configuration) -> {
+    private static boolean registerJAWSDB_MARIA_URL() {
+        return EnvironmentOverride.registerMacro("JAWSDB_MARIA_URL", (environmentValue, configuration) -> {
             if (!configuration.isSet("database.type")) {
                 return;
             }


### PR DESCRIPTION
Java related changes to no longer look for the jawsdb env variable
but instead listen for the maria db version.

This will make auto-updateable avaire's on Heroku no longer work, but if they add the maria db from jawsdb, it will work. They have to somehow migrate the db content themselfs... Or decided not to update.