### PR TITLE
Fix dependency for collections when using Gradle 5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     compile group: 'commons-cli', name: 'commons-cli', version: '1.3.1'
     compile group: 'org.apache.commons', name: 'commons-text', version: '1.1'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.1'
+    compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     compile group: 'org.yaml', name: 'snakeyaml', version: '1.19'
     compile group: 'org.jsoup', name: 'jsoup', version: '1.11.2'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.1'


### PR DESCRIPTION
This fixes a missing dependency (collections) that for some reason only reproduces on gradle 5.0+. I am aware that gradle 5.0 isn't fully supported as of now, but I feel its a good idea to get this out of the way for upgrading in the future. Please test to make sure this still compiles fine on gradle 4.7.