### PR TITLE
Remind command rewrite 

### DIFF
--- a/src/main/java/com/avairebot/Constants.java
+++ b/src/main/java/com/avairebot/Constants.java
@@ -42,6 +42,7 @@ public class Constants {
     public static final String LOG_TYPES_TABLE_NAME = "log_types";
     public static final String REACTION_ROLES_TABLE_NAME = "reaction_roles";
     public static final String PURCHASES_TABLE_NAME = "purchases";
+    public static final String REMINDERS_TABLE_NAME = "reminders";
     public static final String MUTE_TABLE_NAME = "mutes";
     public static final String MUSIC_SEARCH_PROVIDERS_TABLE_NAME = "music_search_providers";
     public static final String MUSIC_SEARCH_CACHE_TABLE_NAME = "music_search_cache";

--- a/src/main/java/com/avairebot/database/controllers/RemindersController.java
+++ b/src/main/java/com/avairebot/database/controllers/RemindersController.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.database.controllers;
+
+import com.avairebot.AvaIre;
+import com.avairebot.Constants;
+import com.avairebot.database.transformers.RemindersTransformer;
+import com.avairebot.utilities.CacheUtil;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import net.dv8tion.jda.core.entities.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+
+public class RemindersController {
+
+    public static final Cache<Long, RemindersTransformer> cache = CacheBuilder.newBuilder()
+                                                                      .recordStats()
+                                                                      .expireAfterAccess(45, TimeUnit.MINUTES)
+                                                                      .build();
+
+    private static final Logger log = LoggerFactory.getLogger(RemindersController.class);
+
+    @Nullable
+    @CheckReturnValue
+    public static RemindersTransformer fetchPendingReminders(User user) {
+        if (user == null || !user.isBot())
+        {
+            return null;
+        }
+        return fetchPendingReminders(user.getIdLong());
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    public static RemindersTransformer fetchPendingReminders(long userId) {
+        return (RemindersTransformer) CacheUtil.getUncheckedUnwrapped(cache, userId, () -> {
+            log.debug("Reminders cache for {} was refreshed", userId);
+            try
+            {
+                return new RemindersTransformer(AvaIre.getInstance().getDatabase()
+                                                    .newQueryBuilder(Constants.REMINDERS_TABLE_NAME)
+                                                    .selectAll()
+                                                    .where("user_id", userId)
+                                                    .andWhere("sent", false)
+                                                    .get());
+            } catch (SQLException e)
+            {
+                log.error("Failed to get reminders for user {}, error: {}", userId, e.getMessage(), e);
+
+                return new RemindersTransformer(null);
+            }
+        });
+    }
+
+
+}

--- a/src/main/java/com/avairebot/database/migrate/migrations/CreateRemindersTableMigration.java
+++ b/src/main/java/com/avairebot/database/migrate/migrations/CreateRemindersTableMigration.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.database.migrate.migrations;
+
+import com.avairebot.Constants;
+import com.avairebot.contracts.database.migrations.Migration;
+import com.avairebot.database.migrate.Migrations;
+import com.avairebot.database.schema.Schema;
+import com.avairebot.time.Carbon;
+
+import java.sql.SQLException;
+
+public class CreateRemindersTableMigration implements Migration {
+
+
+    /**
+     * Gets the time the migration was created at, this is used to order
+     * migrations, making sure migrations are rolled out to the
+     * database and back in the right order.
+     * <p>
+     * The time format can be any of the supported carbon time formats.
+     *
+     * @return the carbon time string
+     *
+     * @see Carbon
+     */
+    @Override
+    public String created_at() {
+        return "Tue, Nov 12, 2019 12:38 PM";
+    }
+
+    /**
+     * Attempts to migrate the database, this is automatically executed from the
+     * {@link Migrations#up() migrate up} method.
+     *
+     * @param schema the database schematic instance
+     * @return the result of the schematic instance call
+     *
+     * @throws SQLException if a database access error occurs,
+     *                      this method is called on a closed <code>Statement</code>, the given
+     *                      SQL statement produces anything other than a single
+     *                      <code>ResultSet</code> object, the method is called on a
+     *                      <code>PreparedStatement</code> or <code>CallableStatement</code>
+     */
+    @Override
+    public boolean up(Schema schema) throws SQLException {
+        return schema.createIfNotExists(Constants.REMINDERS_TABLE_NAME, table -> {
+            table.Increments("id");
+            table.String("user_id");
+            table.String("channel_id").nullable();
+            table.String("message");
+            table.DateTime("stored_at");
+            table.DateTime("expires_at");
+            table.Boolean("sent").defaultValue(false);
+            table.Timestamps();
+        });
+    }
+
+    /**
+     * Attempts to rollback the migrations from the database, this is automatically executed from the
+     * {@link Migrations#down() down()} and
+     * {@link Migrations#rollback(int) rollback(int)} method.
+     *
+     * @param schema the database schematic instance
+     * @return the result of the schematic instance call
+     *
+     * @throws SQLException if a database access error occurs,
+     *                      this method is called on a closed <code>Statement</code>, the given
+     *                      SQL statement produces anything other than a single
+     *                      <code>ResultSet</code> object, the method is called on a
+     *                      <code>PreparedStatement</code> or <code>CallableStatement</code>
+     */
+    @Override
+    public boolean down(Schema schema) throws SQLException {
+        return schema.dropIfExists(Constants.REMINDERS_TABLE_NAME);
+    }
+}

--- a/src/main/java/com/avairebot/database/transformers/RemindersTransformer.java
+++ b/src/main/java/com/avairebot/database/transformers/RemindersTransformer.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.database.transformers;
+
+import com.avairebot.contracts.database.transformers.Transformer;
+import com.avairebot.database.collection.Collection;
+import com.avairebot.database.collection.DataRow;
+import com.avairebot.time.Carbon;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+public class RemindersTransformer extends Transformer {
+    private List<Reminder> reminderList = new ArrayList<>();
+
+
+    /**
+     * Creates a new transformer instance using
+     * the given data row object.
+     */
+    public RemindersTransformer(Collection collection) {
+        super(null);
+
+        if (collection != null && !collection.isEmpty())
+        {
+            for (DataRow row : collection)
+            {
+                if (row == null)
+                {
+                    continue;
+                }
+
+                String id = data.getString("id");
+                String message = new String(Base64.getDecoder().decode(data.getString("message")));
+                long userId = data.getLong("user_id");
+                long guildId = data.getLong("guild_id");
+                String channelId = data.getString("channel_id", null);
+                Carbon expirationDate = data.getTimestamp("expires_at");
+
+                Reminder reminder = new Reminder(message, id, channelId, userId, guildId, expirationDate);
+
+                reminderList.add(reminder);
+            }
+        }
+    }
+
+    @Nonnull
+    public List<Reminder> getReminders() {
+        return reminderList;
+    }
+
+
+    private class Reminder {
+        private String message;
+
+        private String id;
+
+        private String channelId;
+
+        private long userId;
+
+        private long guildId;
+
+        private Carbon expirationDate;
+
+        private Reminder(String message, String id, String channelId, long userId, long guildId, Carbon expirationDate) {
+            this.message = message;
+            this.id = id;
+            this.channelId = channelId;
+            this.userId = userId;
+            this.guildId = guildId;
+            this.expirationDate = expirationDate;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public long getUserId() {
+            return userId;
+        }
+
+        public long getGuildId() {
+            return guildId;
+        }
+
+        @CheckForNull
+        public String getChannelId() {
+            return channelId;
+        }
+
+        public Carbon getExpirationDate() {
+            return expirationDate;
+        }
+
+    }
+}

--- a/src/main/java/com/avairebot/scheduler/jobs/generic/RunEveryMinuteJob.java
+++ b/src/main/java/com/avairebot/scheduler/jobs/generic/RunEveryMinuteJob.java
@@ -38,6 +38,7 @@ public class RunEveryMinuteJob extends Job {
     private final UpdateWebsocketHeartbeatMetricsTask updateWebsocketHeartbeatMetricsTask = new UpdateWebsocketHeartbeatMetricsTask();
     private final SyncValidVoteRequestsWithMetricsTask syncValidVoteRequestsWithMetricsTask = new SyncValidVoteRequestsWithMetricsTask();
     private final SyncPlayerExperienceWithDatabaseTask syncPlayerExperienceWithDatabaseTask = new SyncPlayerExperienceWithDatabaseTask();
+    private final SendRemindersTask sendRemindersTask = new SendRemindersTask();
     private final SyncPlayerUpdateReferencesWithDatabaseTask syncPlayerUpdateReferencesWithDatabaseTask = new SyncPlayerUpdateReferencesWithDatabaseTask();
 
     public RunEveryMinuteJob(AvaIre avaire) {
@@ -50,6 +51,7 @@ public class RunEveryMinuteJob extends Job {
             changeGameTask,
             drainMuteQueueTask,
             garbageCollectorTask,
+            sendRemindersTask,
             syncBlacklistMetricsTask,
             resetRespectStatisticsTask,
             deleteExpiredBlacklistEntitiesTask,

--- a/src/main/java/com/avairebot/scheduler/tasks/SendRemindersTask.java
+++ b/src/main/java/com/avairebot/scheduler/tasks/SendRemindersTask.java
@@ -1,0 +1,111 @@
+package com.avairebot.scheduler.tasks;
+
+import com.avairebot.AvaIre;
+import com.avairebot.Constants;
+import com.avairebot.contracts.scheduler.Task;
+import com.avairebot.database.collection.Collection;
+import com.avairebot.database.collection.DataRow;
+import com.avairebot.time.Carbon;
+import net.dv8tion.jda.core.EmbedBuilder;
+import net.dv8tion.jda.core.MessageBuilder;
+import net.dv8tion.jda.core.entities.Message;
+import net.dv8tion.jda.core.entities.TextChannel;
+import net.dv8tion.jda.core.entities.User;
+
+import java.sql.SQLException;
+import java.util.Base64;
+
+public class SendRemindersTask implements Task {
+    /**
+     * Handles the task when the task is ready to be invoked.
+     *
+     * @param avaire The AvaIre class instance.
+     */
+    @Override
+    public void handle(AvaIre avaire) {
+        try
+        {
+            if (!avaire.getDatabase().getSchema().hasTable(Constants.REMINDERS_TABLE_NAME))
+            {
+                return;
+            }
+
+            Collection collection = avaire.getDatabase().newQueryBuilder(Constants.REMINDERS_TABLE_NAME)
+                                        .useAsync(true)
+                                        .where("sent", false)
+                                        .andWhere("expires_at", "<=", Carbon.now().addMinute())
+                                        .get();
+
+            if (collection.isEmpty())
+            {
+                return;
+            }
+
+            for (DataRow datarow :
+                collection)
+            {
+                int id = datarow.getInt("id");
+                User user = avaire.getShardManager().getUserById(datarow.getString("user_id"));
+                TextChannel textChannel = avaire.getShardManager().getTextChannelById(datarow.getString("channel_id"));
+                String content = new String(Base64.getDecoder().decode(datarow.getString("message")));
+                Carbon timeStamp = datarow.getTimestamp("stored_at");
+                if (textChannel == null || !textChannel.canTalk())
+                {
+                    sendPrivateMessage(avaire, user, content, timeStamp, id);
+                }
+                else
+                {
+                    textChannel.sendMessage(
+                        buildMessage(user, content, timeStamp)
+                    ).queue(
+                        success -> markMessageSent(avaire, id),
+                        error -> sendPrivateMessage(avaire, user, content, timeStamp, id));
+                }
+            }
+
+            avaire.getDatabase().newQueryBuilder(Constants.REMINDERS_TABLE_NAME)
+                .useAsync(true)
+                .where("sent", true)
+                .delete();
+
+        } catch (SQLException ignored)
+        {
+            ignored.printStackTrace();
+        }
+    }
+
+    private void sendPrivateMessage(AvaIre avaire, User user, String content, Carbon timeStamp, int id) {
+        user.openPrivateChannel().queue(message -> message.sendMessage(
+            buildMessage(user, content, timeStamp)).queue(success ->
+            {
+                markMessageSent(avaire, id);
+            }
+        ));
+    }
+
+    private Message buildMessage(User author, String content, Carbon timeStamp) {
+        return new MessageBuilder()
+                   .setContent(String.format("%s, %s you asked to be reminded about:",
+                       author.getAsMention(),
+                       timeStamp.diffForHumans()
+                   ))
+                   .setEmbed(new EmbedBuilder()
+                                 .setDescription(content)
+                                 .build()
+                   ).build();
+    }
+
+    private void markMessageSent(AvaIre avaire, int id) {
+        try
+        {
+            avaire.getDatabase().newQueryBuilder(Constants.REMINDERS_TABLE_NAME)
+                .useAsync(true)
+                .where("id", id)
+                .update(statement -> statement.set("sent", true));
+        } catch (SQLException ignored)
+        {
+            ignored.printStackTrace();
+        }
+
+    }
+}

--- a/src/main/resources/langs/da_DK.yml
+++ b/src/main/resources/langs/da_DK.yml
@@ -892,6 +892,7 @@ utility:
         errors:
             invalidMeHere: 'Ugyldig type angivet, du skal erklære hvor du vil blive påmindet ved enten at bruge `here` for at blive påmindet i denne kanal, eller `me` skal mindes om beskeden i en direkte besked.'
             invalidTime: 'Ugyldig tid angivet, klokkeslættet skal være større end 60 sekunder og mindre end 3 dage.'
+            failedToStoreInfo: "Failed to store reminder."
 
     ServerIdCommand:
         message: ':user :id: for serveren er `:guildid`'

--- a/src/main/resources/langs/de_DE.yml
+++ b/src/main/resources/langs/de_DE.yml
@@ -893,6 +893,7 @@ utility:
         errors:
             invalidMeHere: 'Ungültigen Typ angegeben. Du musst angeben, wo du erinnert werden möchtest. Nutze `here`, um diesen Channel zu nutzen. Falls du eine Direktnachricht bevorzugst, so nutze `me`.'
             invalidTime: 'Ungültige Zeit angegeben. Die Zeit muss länger als 60 Sekunden und weniger als 3 Tage betragen.'
+            failedToStoreInfo: "Failed to store reminder."
 
     ServerIdCommand:
         message: ':user Die :id: vom Server lautet `:guildid`.'

--- a/src/main/resources/langs/en_US.yml
+++ b/src/main/resources/langs/en_US.yml
@@ -892,6 +892,7 @@ utility:
         errors:
             invalidMeHere: 'Invalid type given, you must declare where you want to be reminded, by either using `here` to be reminded in the current channel, or `me` to be reminded in a direct message.'
             invalidTime: 'Invalid time given, the time must be greater than 60 seconds and less than 3 days.'
+            failedToStoreInfo: "Failed to store reminder."
 
     ServerIdCommand:
         message: ':user :id: of this server is `:guildid`'

--- a/src/main/resources/langs/es_ES.yml
+++ b/src/main/resources/langs/es_ES.yml
@@ -893,6 +893,7 @@ utility:
         errors:
             invalidMeHere: 'Tipo no válido. Debes declarar donde debes ser recordado usando `here` en el canal actual o `me` para que se te recuerde a ti directamente a través de un mensaje personal.'
             invalidTime: 'Tiempo no válido. El tiempo debe ser superior a 60 segundos e inferior a 3 días.'
+            failedToStoreInfo: "Failed to store reminder."
 
     ServerIdCommand:
         message: ':user :id: de este servidor es `:guildid`'

--- a/src/main/resources/langs/fr_FR.yml
+++ b/src/main/resources/langs/fr_FR.yml
@@ -892,6 +892,7 @@ utility:
         errors:
             invalidMeHere: 'Invalid type given, you must declare where you want to be reminded by either using `here` to be reminded in the current channel, or `me` to be reminded in a direct message.'
             invalidTime: 'Invalid time given, the time must be greater than 60 seconds and less than 3 days.'
+            failedToStoreInfo: "Failed to store reminder."
 
     ServerIdCommand:
         message: ":user :id: de ce serveur est `:guildid`"

--- a/src/main/resources/langs/hu_HU.yml
+++ b/src/main/resources/langs/hu_HU.yml
@@ -269,14 +269,6 @@ administration:
         notAPunishment: "The modlog case ID with an ID of `{0}` is not a punishment!"
         message: "The modlog case with an ID of **:case** has been been pardoned successfully."
 
-    ModlogPardonCommand:
-        modlogNotEnabled: "No modlog channel has been set, you must set a modlog channel to use this command."
-        invalidCaseId: "Invalid case id given, the ID must be greater than 0 and less than {0}"
-        couldntFindCaseWithId: "Couldn't find a modlog case with an ID of {0} where you were the moderator, are you sure you're the moderator for the given modlog case?"
-        caseAlreadyPardoned: "The modlog case ID with an ID of `{0}` is already pardoned."
-        notAPunishment: "The modlog case ID with an ID of `{0}` is not a punishment!"
-        message: "The modlog case with an ID of **:case** has been been pardoned successfully."
-
     ModlogReasonCommand:
         modlogNotEnabled: "No modlog channel has been set, you must set a modlog channel to use this command."
         invalidCaseId: "Invalid case id given, the ID must be greater than 0 and less than {0}"
@@ -898,6 +890,7 @@ utility:
         errors:
             invalidMeHere: 'Érvénytelen típus megadva, megkell adnod, hogy hol legyél emlékeztetve vagy `here`-el hogy a jelenlegi szobában, vagy `me`-el, hogy privát üzenetben.'
             invalidTime: 'Érvénytelen idő megadva, az értéknek többnek kell lennie mint 60 másodperc és kevesebbnek mint 3 days.'
+            failedToStoreInfo: "Failed to store reminder."
 
     ServerIdCommand:
             message: ':user :id: a szerver ID-je `:guildid`'

--- a/src/main/resources/langs/it_IT.yml
+++ b/src/main/resources/langs/it_IT.yml
@@ -892,6 +892,7 @@ utility:
         errors:
             invalidMeHere: 'Valore non valido, devi dichiarare dove vuoi essere ricordato usando `here` per essere ricordato nel canale corrente, oppure `me` per essere ricordato in un messaggio diretto.'
             invalidTime: 'Tempo non valido, il tempo deve essere superiore a 60 secondi e inferiore a 3 giorni.'
+            failedToStoreInfo: "Failed to store reminder."
 
     ServerIdCommand:
         message: ':user :id: di questo server è `:guildid`'

--- a/src/main/resources/langs/nl_NL.yml
+++ b/src/main/resources/langs/nl_NL.yml
@@ -893,6 +893,7 @@ utility:
         errors:
             invalidMeHere: 'Ongeldig type gegeven, je moet aangeven waar je herinnerd wilt worden, door of `here` te gebruiker om in dit kanaal herinnerd te worden, of `me` om herinnerd te worden in een direct bericht.'
             invalidTime: 'Ongeldige tijd gegeven, de tijd moet meer dan 60 seconden zijn en minder dan 3 dagen.'
+            failedToStoreInfo: "Failed to store reminder."
 
     ServerIdCommand:
         message: ':user :id: van deze server is `:guildid`'

--- a/src/main/resources/langs/no_NB.yml
+++ b/src/main/resources/langs/no_NB.yml
@@ -893,6 +893,7 @@ utility:
         errors:
             invalidMeHere: 'Invalid type given, you must declare where you want to be reminded by either using `here` to be reminded in the current channel, or `me` to be reminded in a direct message.'
             invalidTime: 'Invalid time given, the time must be greater than 60 seconds and less than 3 days.'
+            failedToStoreInfo: "Failed to store reminder."
 
     ServerIdCommand:
         message: ':user :id: til denne serveren er `:guildid`'

--- a/src/main/resources/langs/ru_RU.yml
+++ b/src/main/resources/langs/ru_RU.yml
@@ -893,6 +893,7 @@ utility:
         errors:
             invalidMeHere: 'Недопустимый тип данных, вы должны объявить, где вам нужно напомнить, либо используя `here`, чтобы напомнить в текущем канале, либо `me`, чтобы напомнить в прямом сообщении.'
             invalidTime: 'Недействительное время, время должно быть больше 60 секунд и менее 3 дней.'
+            failedToStoreInfo: "Failed to store reminder."
 
     ServerIdCommand:
         message: ':user :id: этого сервера `:guildid`'

--- a/src/main/resources/langs/zh_SI.yml
+++ b/src/main/resources/langs/zh_SI.yml
@@ -891,6 +891,7 @@ utility:
         errors:
             invalidMeHere: '类型指定无效，则必须声明要提醒您的位置，方法是使用 `here` 在当前频道中被提醒，或 `me` 在直接信息中被提醒.'
             invalidTime: '给定的时间无效，时间必须大于60秒且小于3天。'
+            failedToStoreInfo: "Failed to store reminder."
 
     ServerIdCommand:
         message: ':user :id: 此服务器的 `:guildid`'


### PR DESCRIPTION
Work on making the remind command use the database properly. So far we have the database storing the information from the command and being removed by a task. The "reminders" has an automatically incrementing id, user id, nullable channel id, message encoded with base64, an stored at datetime, and an expires at datetime. In addition I am testing to see if auto-formatting works properly with IntelliJ idea with this commit.

Things that are huge priority to fix are:
1) The database gets hit every single minute by the SendRemindersTask
2) Users cannot list their pending reminders.
3) The cache is not being used anywhere and remains untested.
4) Users cannot cancel any pending reminders manually yet.