### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Build container
+
+FROM gradle:4.10.2-jdk11-slim AS build
+
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle build --no-daemon
+
+# Run container
+
+FROM openjdk:11-jre-slim AS runtime
+
+WORKDIR /opt/avaire/
+
+RUN adduser --disabled-password --gecos '' avaire; \
+    chown avaire:avaire -R /opt/avaire; \
+    chmod u+w /opt/avaire; \
+    chmod 0755 -R /opt/avaire
+
+USER avaire
+
+COPY --from=build /home/gradle/src/AvaIre.jar /bin/
+
+CMD ["java","-jar","/bin/AvaIre.jar","-env","--use-plugin-index"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.7"
+services:
+    avaire:
+        image: avaire
+        build:
+            context: .
+        depends_on:
+            - avairedb
+        restart: on-failure
+        environment:
+            - AVA_DATABASE_DATABASE=avaire
+            - AVA_DATABASE_HOSTNAME=avairedb
+            - AVA_DATABASE_USERNAME=avaire
+            - AVA_DATABASE_PASSWORD=avaire
+        volumes:
+            - C:\avaire:/opt/avaire
+    avairedb:
+        container_name: avairedb
+        image: mariadb
+        restart: on-failure
+        expose:
+            - "3306"
+        environment:
+            - MYSQL_DATABASE=avaire
+            - MYSQL_USER=avaire
+            - MYSQL_PASSWORD=avaire
+            - MYSQL_RANDOM_ROOT_PASSWORD=yes
+volumes:
+    avaire:


### PR DESCRIPTION
Firstly, thanks to the previous pulls: #68 #95 and Steve from Discord with helping me understand Docker(-Compose)!

This pull aims to bring full support for Docker for AvaIre. This includes composer and also docs to help each user on Mac/Win and Linux build their own instance of AvaIre with Docker!

The Website repo will recieve Docker support aswell when the conntection has been realised between the website/dashboard and AvaIre.

If any other parts of AvaIre would need support, just ask and i'll look at them aswell :-)

This pull already uses JDK11 for the runtime, as it seems to work fine and takes some work off from the #64 pull.

Todo:
make docs for both watchdog and avaire so users know how to start.