### PR TITLE
Modify the create reaction role command to support unicode emotes as …

### DIFF
--- a/src/main/java/com/avairebot/database/transformers/ReactionTransformer.java
+++ b/src/main/java/com/avairebot/database/transformers/ReactionTransformer.java
@@ -25,6 +25,7 @@ import com.avairebot.AvaIre;
 import com.avairebot.contracts.database.transformers.Transformer;
 import com.avairebot.database.collection.DataRow;
 import com.google.gson.reflect.TypeToken;
+import com.vdurmont.emoji.Emoji;
 import net.dv8tion.jda.core.entities.Emote;
 import net.dv8tion.jda.core.entities.Role;
 
@@ -35,7 +36,7 @@ import java.util.Map;
 
 public class ReactionTransformer extends Transformer {
 
-    private final Map<Long, Long> roles = new HashMap<>();
+    private final Map<String, Long> roles = new HashMap<>();
 
     private long guildId = -1;
     private long channelId = -1;
@@ -55,13 +56,15 @@ public class ReactionTransformer extends Transformer {
             channelId = row.getLong("channel_id");
             messageId = row.getLong("message_id");
 
-            if (data.getString("roles", null) != null) {
-                HashMap<Long, Long> dbRoles = AvaIre.gson.fromJson(
+            if (data.getString("roles", null) != null)
+            {
+                HashMap<String, Long> dbRoles = AvaIre.gson.fromJson(
                     data.getString("roles"),
-                    new TypeToken<HashMap<Long, Long>>() {
+                    new TypeToken<HashMap<String, Long>>() {
                     }.getType());
 
-                for (Map.Entry<Long, Long> item : dbRoles.entrySet()) {
+                for (Map.Entry<String, Long> item : dbRoles.entrySet())
+                {
                     roles.put(item.getKey(), item.getValue());
                 }
             }
@@ -78,10 +81,28 @@ public class ReactionTransformer extends Transformer {
      */
     @Nullable
     public Long getRoleIdFromEmote(@Nonnull Emote emote) {
-        if (!roles.containsKey(emote.getIdLong())) {
+        if (!roles.containsKey(emote.getId()))
+        {
             return null;
         }
-        return roles.get(emote.getIdLong());
+        return roles.get(emote.getId());
+    }
+
+    /**
+     * Gets the role ID that is attached to the given emote, if
+     * no role is linked with the given emote then
+     * {@code NULL} will be returned instead.
+     *
+     * @param unicodeEmote The unicode expression that should be used to get the role id
+     * @return Possibly-null, the ID of the role that is linked/attached to the given unicode emote.
+     */
+    @Nullable
+    public Long getRoleIdFromEmoji(@Nonnull Emoji unicodeEmote) {
+        if (!roles.containsKey(unicodeEmote.getUnicode()))
+        {
+            return null;
+        }
+        return roles.get(unicodeEmote.getUnicode());
     }
 
     /**
@@ -93,7 +114,19 @@ public class ReactionTransformer extends Transformer {
      * @param role  The role that should be linked to the given emote.
      */
     public void addReaction(@Nonnull Emote emote, @Nonnull Role role) {
-        roles.put(emote.getIdLong(), role.getIdLong());
+        roles.put(emote.getId(), role.getIdLong());
+    }
+
+    /**
+     * Adds the reaction to the current reaction message, linking the
+     * given emoji and role so when a user reactions to the message
+     * with the given emote, they will be giving the role.
+     *
+     * @param emoji The emote that should be added to the reaction message.
+     * @param role  The role that should be linked to the given emote.
+     */
+    public void addReaction(@Nonnull Emoji emoji, @Nonnull Role role) {
+        roles.put(emoji.getUnicode(), role.getIdLong());
     }
 
     /**
@@ -103,8 +136,9 @@ public class ReactionTransformer extends Transformer {
      * @return {@code True} if the emote was removed from the message, or {@code False} if it wasn't added in the first place.
      */
     public boolean removeReaction(@Nonnull Emote emote) {
-        if (roles.containsKey(emote.getIdLong())) {
-            roles.remove(emote.getIdLong());
+        if (roles.containsKey(emote.getId()))
+        {
+            roles.remove(emote.getId());
             return true;
         }
         return false;
@@ -116,7 +150,7 @@ public class ReactionTransformer extends Transformer {
      *
      * @return A map of the roles attached to the reaction message.
      */
-    public Map<Long, Long> getRoles() {
+    public Map<String, Long> getRoles() {
         return roles;
     }
 

--- a/src/main/java/com/avairebot/handlers/MainEventHandler.java
+++ b/src/main/java/com/avairebot/handlers/MainEventHandler.java
@@ -26,6 +26,7 @@ import com.avairebot.contracts.handlers.EventHandler;
 import com.avairebot.database.controllers.PlayerController;
 import com.avairebot.handlers.adapter.*;
 import com.avairebot.metrics.Metrics;
+import com.vdurmont.emoji.EmojiManager;
 import net.dv8tion.jda.core.events.Event;
 import net.dv8tion.jda.core.events.ReadyEvent;
 import net.dv8tion.jda.core.events.ReconnectedEvent;
@@ -263,7 +264,8 @@ public class MainEventHandler extends EventHandler {
 
     @Override
     public void onMessageReactionRemove(MessageReactionRemoveEvent event) {
-        if (isValidMessageReactionEvent(event)) {
+        if (isValidMessageReactionEvent(event))
+        {
             reactionEmoteEventAdapter.onMessageReactionRemove(event);
         }
     }
@@ -271,6 +273,6 @@ public class MainEventHandler extends EventHandler {
     private boolean isValidMessageReactionEvent(GenericMessageReactionEvent event) {
         return !event.getUser().isBot()
             && event.getGuild() != null
-            && event.getReactionEmote().getEmote() != null;
+            && (event.getReactionEmote().getEmote() != null || EmojiManager.isEmoji(event.getReactionEmote().getName()));
     }
 }

--- a/src/main/java/com/avairebot/handlers/adapter/ReactionEmoteEventAdapter.java
+++ b/src/main/java/com/avairebot/handlers/adapter/ReactionEmoteEventAdapter.java
@@ -31,6 +31,7 @@ import com.avairebot.database.query.QueryBuilder;
 import com.avairebot.database.transformers.ReactionTransformer;
 import com.avairebot.scheduler.tasks.DrainReactionRoleQueueTask;
 import com.avairebot.utilities.RoleUtil;
+import com.vdurmont.emoji.EmojiManager;
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Role;
@@ -90,20 +91,43 @@ public class ReactionEmoteEventAdapter extends EventAdapter {
 
     @SuppressWarnings("ConstantConditions")
     public void onMessageReactionAdd(MessageReactionAddEvent event) {
-        ReactionTransformer transformer = getReactionTransformerFromMessageIdAndCheckPermissions(
-            event.getGuild(), event.getMessageId(), event.getReactionEmote().getEmote().getIdLong()
-        );
+        ReactionTransformer transformer;
 
-        if (transformer == null) {
+        if (event.getReactionEmote().isEmote())
+        {
+            transformer = getReactionTransformerFromMessageIdAndCheckPermissions(
+                event.getGuild(), event.getMessageId(), event.getReactionEmote().getEmote().getId()
+            );
+        }
+        else
+        {
+            transformer = getReactionTransformerFromMessageIdAndCheckPermissions(
+                event.getGuild(), event.getMessageId(), event.getReactionEmote().getName()
+            );
+        }
+
+        if (transformer == null)
+        {
             return;
         }
 
-        Role role = event.getGuild().getRoleById(transformer.getRoleIdFromEmote(event.getReactionEmote().getEmote()));
-        if (role == null) {
+        Role role;
+        if (!event.getReactionEmote().isEmote())
+        {
+            role = event.getGuild().getRoleById(transformer.getRoleIdFromEmoji(EmojiManager.getByUnicode(event.getReactionEmote().getName())));
+        }
+        else
+        {
+            role = event.getGuild().getRoleById(transformer.getRoleIdFromEmote(event.getReactionEmote().getEmote()));
+        }
+
+        if (role == null)
+        {
             return;
         }
 
-        if (RoleUtil.hasRole(event.getMember(), role) || !event.getGuild().getSelfMember().canInteract(role)) {
+        if (RoleUtil.hasRole(event.getMember(), role) || !event.getGuild().getSelfMember().canInteract(role))
+        {
             return;
         }
 
@@ -117,20 +141,43 @@ public class ReactionEmoteEventAdapter extends EventAdapter {
 
     @SuppressWarnings("ConstantConditions")
     public void onMessageReactionRemove(MessageReactionRemoveEvent event) {
-        ReactionTransformer transformer = getReactionTransformerFromMessageIdAndCheckPermissions(
-            event.getGuild(), event.getMessageId(), event.getReactionEmote().getEmote().getIdLong()
-        );
+        ReactionTransformer transformer;
 
-        if (transformer == null) {
+        if (event.getReactionEmote().isEmote())
+        {
+            transformer = getReactionTransformerFromMessageIdAndCheckPermissions(
+                event.getGuild(), event.getMessageId(), event.getReactionEmote().getEmote().getId()
+            );
+        }
+        else
+        {
+            transformer = getReactionTransformerFromMessageIdAndCheckPermissions(
+                event.getGuild(), event.getMessageId(), event.getReactionEmote().getName()
+            );
+        }
+
+        if (transformer == null)
+        {
             return;
         }
 
-        Role role = event.getGuild().getRoleById(transformer.getRoleIdFromEmote(event.getReactionEmote().getEmote()));
-        if (role == null) {
+        Role role;
+        if (!event.getReactionEmote().isEmote())
+        {
+            role = event.getGuild().getRoleById(transformer.getRoleIdFromEmoji(EmojiManager.getByUnicode(event.getReactionEmote().getName())));
+        }
+        else
+        {
+            role = event.getGuild().getRoleById(transformer.getRoleIdFromEmote(event.getReactionEmote().getEmote()));
+        }
+
+        if (role == null)
+        {
             return;
         }
 
-        if (!RoleUtil.hasRole(event.getMember(), role) || !event.getGuild().getSelfMember().canInteract(role)) {
+        if (!RoleUtil.hasRole(event.getMember(), role) || !event.getGuild().getSelfMember().canInteract(role))
+        {
             return;
         }
 
@@ -142,18 +189,22 @@ public class ReactionEmoteEventAdapter extends EventAdapter {
         ));
     }
 
-    private ReactionTransformer getReactionTransformerFromMessageIdAndCheckPermissions(@Nonnull Guild guild, @Nonnull String messageId, long emoteId) {
-        if (!hasPermission(guild)) {
+    private ReactionTransformer getReactionTransformerFromMessageIdAndCheckPermissions(@Nonnull Guild guild, @Nonnull String messageId, String emoteId) {
+        if (!hasPermission(guild))
+        {
             return null;
         }
 
         Collection collection = ReactionController.fetchReactions(avaire, guild);
-        if (collection == null || collection.isEmpty()) {
+        if (collection == null || collection.isEmpty())
+        {
             return null;
         }
 
         ReactionTransformer transformer = getReactionTransformerFromId(collection, messageId);
-        if (transformer == null || !transformer.getRoles().containsKey(emoteId)) {
+
+        if (transformer == null || !transformer.getRoles().containsKey(emoteId))
+        {
             return null;
         }
         return transformer;


### PR DESCRIPTION
…well as the custom guild emotes. The key for the emote id was changed to a string instead of a long, but theoretically it should still be compatible with existing reaction roles. Several additional methods were created to handle the alternative objects. Hopefully everything is in order.