### PR TITLE
Add duration to play command listing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'idea'
 
-version = '0.9.181'
+version = '0.9.182'
 group = 'com.avairebot'
 description = 'AvaIre Discord Bot'
 mainClassName = 'com.avairebot.Main'

--- a/src/main/java/com/avairebot/commands/music/PlayCommand.java
+++ b/src/main/java/com/avairebot/commands/music/PlayCommand.java
@@ -226,8 +226,8 @@ public class PlayCommand extends Command {
 
                 AudioTrack track = tracks.get(i);
 
-                songs.add(String.format("`%s` [%s](%s)",
-                    (i + 1), track.getInfo().title, track.getInfo().uri
+                songs.add(String.format("`%s` [%s](%s) [%s]",
+                    (i + 1), track.getInfo().title, track.getInfo().uri, NumberUtil.formatTime(track.getDuration())
                 ));
             }
 


### PR DESCRIPTION
Users should now have an idea an song is before they queue it. This may prevent users from starting and stopping songs over and over again looking for the right song.