### PR TITLE
Update to a much later version of JUnit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,9 +106,9 @@ dependencies {
 
     // Tests
     // Only needed to run tests in a version of IntelliJ IDEA that bundles older versions
-    compile("org.junit.platform:junit-platform-launcher:1.1.0")
-    compile("org.junit.jupiter:junit-jupiter-engine:5.1.0")
-    compile("org.junit.vintage:junit-vintage-engine:5.1.0")
+    compile("org.junit.platform:junit-platform-launcher:1.6.2")
+    compile("org.junit.jupiter:junit-jupiter-engine:5.6.2")
+    compile("org.junit.vintage:junit-vintage-engine:5.6.2")
 }
 
 import org.apache.tools.ant.filters.ReplaceTokens


### PR DESCRIPTION
It is required in order to be able to build on later versions of the Java Runtime such as Java 12. Otherwise it will fail while building on the ":compileTestJava" stage. 