### PR TITLE
Fixes for meme and gfycat commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'idea'
 
-version = '0.10.5'
+version = '0.10.6'
 group = 'com.avairebot'
 description = 'AvaIre Discord Bot'
 mainClassName = 'com.avairebot.Main'

--- a/src/main/java/com/avairebot/commands/search/GfycatCommand.java
+++ b/src/main/java/com/avairebot/commands/search/GfycatCommand.java
@@ -76,7 +76,7 @@ public class GfycatCommand extends Command {
             return sendErrorMessage(context, "errors.missingArgument", "queue");
         }
 
-        RequestFactory.makeGET("https://api.gfycat.com/v1test/gfycats/search")
+        RequestFactory.makeGET("https://api.gfycat.com/v1/gfycats/search")
             .addParameter("count", 25)
             .addParameter("search_text", String.join(" ", args))
             .send((Consumer<Response>) response -> {

--- a/src/main/java/com/avairebot/scheduler/jobs/FetchMemeTypesJob.java
+++ b/src/main/java/com/avairebot/scheduler/jobs/FetchMemeTypesJob.java
@@ -39,7 +39,7 @@ public class FetchMemeTypesJob extends Job {
     private final String apiEndpoint = "https://memegen.link/api/templates/";
 
     public FetchMemeTypesJob(AvaIre avaire) {
-        super(avaire, 7, 7, TimeUnit.DAYS);
+        super(avaire, 3, 3, TimeUnit.DAYS);
 
         if (!avaire.getCache().getAdapter(CacheType.FILE).has(cacheToken)) {
             run();

--- a/src/main/java/com/avairebot/scheduler/jobs/FetchMemeTypesJob.java
+++ b/src/main/java/com/avairebot/scheduler/jobs/FetchMemeTypesJob.java
@@ -60,12 +60,11 @@ public class FetchMemeTypesJob extends Job {
                         HashMap<String, String> meme = new HashMap<>();
                         meme.put("name", entry.getKey());
                         meme.put("url", entry.getValue());
-                        
-                        if(entry.getValue().startsWith("https")) {
+
+                        if (entry.getValue().startsWith("https")) {
                             cache.put(entry.getValue().substring(apiEndpoint.length(), entry.getValue().length()), meme);
-                        }
-                        else {
-                            cache.put(entry.getValue().substring(apiEndpoint.length()-1, entry.getValue().length()), meme);
+                        } else {
+                            cache.put(entry.getValue().substring(apiEndpoint.length() - 1, entry.getValue().length()), meme);
                         }
                     }
 

--- a/src/main/java/com/avairebot/scheduler/jobs/FetchMemeTypesJob.java
+++ b/src/main/java/com/avairebot/scheduler/jobs/FetchMemeTypesJob.java
@@ -60,9 +60,13 @@ public class FetchMemeTypesJob extends Job {
                         HashMap<String, String> meme = new HashMap<>();
                         meme.put("name", entry.getKey());
                         meme.put("url", entry.getValue());
-
-                        cache.put(entry.getValue().substring(apiEndpoint.length(), entry.getValue().length()), meme);
-
+                        
+                        if(entry.getValue().startsWith("https")) {
+                            cache.put(entry.getValue().substring(apiEndpoint.length(), entry.getValue().length()), meme);
+                        }
+                        else {
+                            cache.put(entry.getValue().substring(apiEndpoint.length()-1, entry.getValue().length()), meme);
+                        }
                     }
 
                     avaire.getCache().getAdapter(CacheType.FILE).forever(cacheToken, cache);


### PR DESCRIPTION
memegen.link API generates links in the format of "http://" instead of "https://" that this code is considering. This results in the loss of the first character in every single meme name, since it's directly considering the length of the "https" apiEndpoint string. This fix adds a check to use the correct length depending on whether the start of the links are http or https, so that the code will not break even when the API switches back to https-based links.