### PR TITLE
Remove depreciated methods

### DIFF
--- a/src/main/java/com/avairebot/audio/AudioHandler.java
+++ b/src/main/java/com/avairebot/audio/AudioHandler.java
@@ -297,7 +297,7 @@ public class AudioHandler {
             }
 
             AudioManager audioManager = manager.getLastActiveMessage().getGuild().getAudioManager();
-            if (audioManager.isConnected() || audioManager.isAttemptingToConnect()) {
+            if (audioManager.isConnected()) {
                 total++;
             }
         }

--- a/src/main/java/com/avairebot/handlers/MainEventHandler.java
+++ b/src/main/java/com/avairebot/handlers/MainEventHandler.java
@@ -122,12 +122,12 @@ public class MainEventHandler extends EventHandler {
     }
 
     @Override
-    public void onResume(ResumedEvent event) {
+    public void onResumed(ResumedEvent event) {
         jdaStateEventAdapter.onConnectToShard(event.getJDA());
     }
 
     @Override
-    public void onReconnect(ReconnectedEvent event) {
+    public void onReconnected(ReconnectedEvent event) {
         jdaStateEventAdapter.onConnectToShard(event.getJDA());
     }
 

--- a/src/main/java/com/avairebot/scheduler/tasks/GarbageCollectorTask.java
+++ b/src/main/java/com/avairebot/scheduler/tasks/GarbageCollectorTask.java
@@ -77,7 +77,7 @@ public class GarbageCollectorTask implements Task {
      * @return True if the audio manager is connected, false otherwise.
      */
     private boolean isConnected(AudioManager audioManager) {
-        return audioManager.isConnected() || audioManager.isAttemptingToConnect();
+        return audioManager.isConnected();
     }
 
     /**


### PR DESCRIPTION
All the methods that were marked as deprecated in v4 have been appropriately dealt with. AudioManager.isAttemptingToConnect was marked for removal and onResume and onReconnect were renamed. No other code can be altered for the upgrade to JDA v5 unfortunately.